### PR TITLE
Fix robust_fit for large timestamps by subtracting offset

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -703,8 +703,9 @@ def _robust_fit(A, y, rho=1, iters=1000):
     http://www.stanford.edu/~boyd/papers/distr_opt_stat_learning_admm.html
 
     """
+    A = np.copy(A)  # Don't mutate input.
     offset = np.min(A[:, 1])
-    A[:, 1] = A[:, 1] - offset  # Don't use -= operator here!
+    A[:, 1] -= offset
     Aty = np.dot(A.T, y)
     L = np.linalg.cholesky(np.dot(A.T, A))
     U = L.T


### PR DESCRIPTION
Fixes issue reported [here](https://github.com/labstreaminglayer/App-LabRecorder/issues/44) and by user in Slack.

Briefly, very large timestamp values (especially on systems using seconds since 1970) lead to instabilities due to insufficient numerical precision. Here we subtract a constant from the timestamps before calculating the fit between timestamps and offsets. The offset is added back before returning.

There was also a little extra to be done to keep winsor_threshold functioning properly.

Sister PR in Matlab: https://github.com/xdf-modules/xdf-Matlab/pull/9

