### PR TITLE
Remove deprecated np.object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- Fix invalid `np.object` type ([#87](https://github.com/xdf-modules/xdf-Python/pull/87) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.16.3] - 2020-08-07
 ### Added
 - Add Cython type hints (requires optional local compilation) ([#17](https://github.com/xdf-modules/xdf-python/pull/17) by [Tristan Stenner](https://github.com/tstenner))

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -34,7 +34,7 @@ class StreamData:
         fmts = dict(
             double64=np.float64,
             float32=np.float32,
-            string=np.object,
+            string=object,
             int32=np.int32,
             int16=np.int16,
             int8=np.int8,


### PR DESCRIPTION
Replacing `np.object` with `object` should do the trick. This is required for NumPy >= 1.24.