### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.16.5] - 2024-01-12
+### Added
+- Added compatibility with Python 3.12 ([#96](https://github.com/xdf-modules/xdf-Python/pull/96) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.16.4] - 2023-01-09
 ### Fixed
 - Fix invalid `np.object` type ([#87](https://github.com/xdf-modules/xdf-Python/pull/87) by [Clemens Brunner](https://github.com/cbrnr))

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -3,11 +3,16 @@
 #
 # License: BSD (2-clause)
 
-from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # package is not installed
-    __version__ = None
+    from pkg_resources import get_distribution, DistributionNotFound
+except ImportError:
+    from importlib.metadata import version
+    __version__ = version(__name__)
+else:
+    try:
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:  # package is not installed
+        __version__ = None
 from .pyxdf import load_xdf, resolve_streams, match_streaminfos
 
 __all__ = [load_xdf, resolve_streams, match_streaminfos]


### PR DESCRIPTION
Starting with Python 3.12, `pkg_resources` is no longer available, and it is recommended to use `importlib.metadata` instead.

If we drop support for Python < 3.8, we could get rid of `pkg_resources` completely (and therefore simplify the code required to get the version). Almost all scientific Python packages support the last 3 to 4 Python versions only, and I think we should do that too. We can keep Python 3.8 support for now, which means that we'd support five versions.