### PR TITLE
In setup.cfg, replace deprecated license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 # includes the license file in the wheel
-license_file = LICENSE
+license_files = LICENSE
 
 [bdist_wheel]
 # our code is written to work on both Python 2 and 3


### PR DESCRIPTION
Use license_files instead.

Fixes:

> _DeprecatedConfig: Deprecated config in `setup.cfg`
> !!
>
>         ********************************************************************************
>         The license_file parameter is deprecated, use license_files instead.
>
>         This deprecation is overdue, please update your project and remove deprecated
>         calls to avoid build errors in the future.
>
>         See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
>         ********************************************************************************
>
> !!