### PR TITLE
Fix reading numeric array data on big-endian hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- Fix reading numeric array data on big-endian hosts ([#98](https://github.com/xdf-modules/pyxdf/pull/98) by [Ben Beasley](https://github.com/musicinmybrain))
 
 ## [1.16.7] - 2024-07-17
 ### Added

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -468,7 +468,9 @@ def _read_chunk3(f, s):
             f.readinto(raw)
             # no fromfile(), see
             # https://github.com/numpy/numpy/issues/13319
-            values[k, :] = np.frombuffer(raw, dtype=s.dtype, count=s.nchns)
+            values[k, :] = np.frombuffer(
+                raw, dtype=s.dtype.newbyteorder("<"), count=s.nchns
+            )
     return nsamples, stamps, values
 
 


### PR DESCRIPTION
Fixes a test failure when the [Fedora Linux package](https://src.fedoraproject.org/rpms/python-pyxdf) is built and tested on `s390x`, which is Fedora’s sole big-endian primary architecture:

```
=================================== FAILURES ===================================
__________________ test_load_file[example-files/minimal.xdf] ___________________
file = 'example-files/minimal.xdf'
    @pytest.mark.parametrize("file", files)
    def test_load_file(file):
        streams, header = load_xdf(file)
    
        if file.endswith("minimal.xdf"):
            assert header["info"]["version"][0] == "1.0"
    
            assert len(streams) == 2
            assert streams[0]["info"]["name"][0] == "SendDataC"
            assert streams[0]["info"]["type"][0] == "EEG"
            assert streams[0]["info"]["channel_count"][0] == "3"
            assert streams[0]["info"]["nominal_srate"][0] == "10"
            assert streams[0]["info"]["channel_format"][0] == "int16"
            assert streams[0]["info"]["stream_id"] == 0
    
            s = np.array([[192, 255, 238],
                          [12, 22, 32],
                          [13, 23, 33],
                          [14, 24, 34],
                          [15, 25, 35],
                          [12, 22, 32],
                          [13, 23, 33],
                          [14, 24, 34],
                          [15, 25, 35]], dtype=np.int16)
            t = np.array([5., 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8])
>           np.testing.assert_array_equal(streams[0]["time_series"], s)
pyxdf/test/test_data.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
args = (<built-in function eq>, array([[-16384,   -256,  -4608],
       [  3072,   5632,   8192],
       [  3328,   5888,   8...5,  35],
       [ 12,  22,  32],
       [ 13,  23,  33],
       [ 14,  24,  34],
       [ 15,  25,  35]], dtype=int16))
kwds = {'err_msg': '', 'header': 'Arrays are not equal', 'strict': False, 'verbose': True}
    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Arrays are not equal
E           
E           Mismatched elements: 27 / 27 (100%)
E           Max absolute difference: 16576
E           Max relative difference: 255.
E            x: array([[-16384,   -256,  -4608],
E                  [  3072,   5632,   8192],
E                  [  3328,   5888,   8448],...
E            y: array([[192, 255, 238],
E                  [ 12,  22,  32],
E                  [ 13,  23,  33],...
/usr/lib64/python3.11/contextlib.py:81: AssertionError
=========================== short test summary info ============================
FAILED pyxdf/test/test_data.py::test_load_file[example-files/minimal.xdf] - A...
========================= 1 failed, 4 passed in 0.33s ==========================
```

Fortunately, it looks like this is the only place where the implementation accidentally assumes the host is little-endian.

Reference: https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html