### PR TITLE
avoid crash on corrupt footer

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -13,7 +13,7 @@ import io
 import struct
 import itertools
 import gzip
-from xml.etree.ElementTree import fromstring
+from xml.etree.ElementTree import fromstring, ParseError
 from collections import OrderedDict, defaultdict
 import logging
 from pathlib import Path
@@ -330,14 +330,11 @@ def load_xdf(
                 xml_string = f.read(chunklen - 6)
                 try:
                     streams[StreamId]["footer"] = _xml2dict(fromstring(xml_string))
-                except Exception as e:
-                    if type(e).__name__ == 'ParseError':
-                        logger.error(
-                            "found likely XDF file corruption (%s), "
-                            "ignoring corrupted XML element in footer." % e
-                        )
-                    else:
-                        raise
+                except ParseError as e:
+                    logger.error(
+                        "found likely XDF file corruption (%s), "
+                        "ignoring corrupted XML element in footer." % e
+                    )
             elif tag == 4:
                 # read [ClockOffset] chunk
                 temp[StreamId].clock_times.append(

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -332,8 +332,8 @@ def load_xdf(
                     streams[StreamId]["footer"] = _xml2dict(fromstring(xml_string))
                 except ParseError as e:
                     logger.error(
-                        "found likely XDF file corruption (%s), "
-                        "ignoring corrupted XML element in footer." % e
+                        f"found likely XDF file corruption ({e}), "
+                        "ignoring corrupted XML element in footer."
                     )
             elif tag == 4:
                 # read [ClockOffset] chunk

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -328,7 +328,16 @@ def load_xdf(
             elif tag == 6:
                 # read [StreamFooter] chunk
                 xml_string = f.read(chunklen - 6)
-                streams[StreamId]["footer"] = _xml2dict(fromstring(xml_string))
+                try:
+                    streams[StreamId]["footer"] = _xml2dict(fromstring(xml_string))
+                except Exception as e:
+                    if type(e).__name__ == 'ParseError':
+                        logger.error(
+                            "found likely XDF file corruption (%s), "
+                            "ignoring corrupted XML element in footer." % e
+                        )
+                    else:
+                        raise
             elif tag == 4:
                 # read [ClockOffset] chunk
                 temp[StreamId].clock_times.append(


### PR DESCRIPTION
equivalent of https://github.com/xdf-modules/xdf-Matlab/pull/19 but for pyxdf
closes https://github.com/labstreaminglayer/App-LabRecorder/issues/107 