### PR TITLE
Bump to Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- Minimum required Python version is now 3.9 ([#100](https://github.com/xdf-modules/xdf-Python/pull/100) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.16.5] - 2024-01-12
 ### Added
 - Added compatibility with Python 3.12 ([#96](https://github.com/xdf-modules/xdf-Python/pull/96) by [Clemens Brunner](https://github.com/cbrnr))

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
 BSD 2-Clause License
 
-Copyright (c) 2015-2023, Syntrogi Inc. dba Intheon
-Copyright (c) 2018-2023, Chad Boulay
-Copyright (c) 2018-2023, Tristan Stenner
-Copyright (c) 2018-2023, Clemens Brunner
+Copyright (c) 2015-2024, Syntrogi Inc. dba Intheon
+Copyright (c) 2018-2024, Chad Boulay
+Copyright (c) 2018-2024, Tristan Stenner
+Copyright (c) 2018-2024, Clemens Brunner
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Latest PyPI Release](https://img.shields.io/pypi/v/pyxdf)](https://pypi.org/project/pyxdf/)
 [![Latest Conda Release](https://img.shields.io/conda/vn/conda-forge/pyxdf)](https://anaconda.org/conda-forge/pyxdf)
-![Python 3.5+](https://img.shields.io/badge/python-3.5+-green.svg)
+![Python 3.9+](https://img.shields.io/badge/python-3.9+-green.svg)
 ![License](https://img.shields.io/github/license/xdf-modules/xdf-python)
 
 pyXDF
@@ -34,9 +34,9 @@ for stream in data:
 plt.show()
 ```
 
-## CLI Examples
+## CLI examples
 
-`pyxdf` has an `examples` module. These can be run from the commandline for basic functionality.
+`pyxdf` has an `examples` module. These can be run from the command line for basic functionality.
 
 * `print_metadata` will enable a DEBUG logger to log read messages, then it will print basic metadata about each found stream.
     * `python -m pyxdf.examples.print_metadata -f=/path/to/my.xdf`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python37:
-      python.version: '3.7'
+    Python39:
+      python.version: '3.9'
 
 steps:
 - task: UsePythonVersion@0

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -5,7 +5,7 @@
 
 try:
     from pkg_resources import get_distribution, DistributionNotFound
-except ImportError:
+except (DeprecationWarning, ImportError):
     from importlib.metadata import version
     __version__ = version(__name__)
 else:

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -3,16 +3,13 @@
 #
 # License: BSD (2-clause)
 
+from importlib.metadata import PackageNotFoundError, version
+
 try:
-    from pkg_resources import get_distribution, DistributionNotFound
-except (DeprecationWarning, ImportError):
-    from importlib.metadata import version
     __version__ = version(__name__)
-else:
-    try:
-        __version__ = get_distribution(__name__).version
-    except DistributionNotFound:  # package is not installed
-        __version__ = None
-from .pyxdf import load_xdf, resolve_streams, match_streaminfos
+except PackageNotFoundError:
+    __version__ = None
+
+from .pyxdf import load_xdf, match_streaminfos, resolve_streams
 
 __all__ = [load_xdf, resolve_streams, match_streaminfos]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "pyxdf",
         "LSL",
         "Lab Streaming Layer",
-        "File Format",
+        "file format",
         "biosignals",
         "stream",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,91 +14,48 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='pyxdf',
-
-    # Get version from git tag: https://pypi.org/project/setuptools-scm/
+    name="pyxdf",
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
-
-    description='Python library for importing XDF (Extensible Data Format)',
+    setup_requires=["setuptools_scm"],
+    description="Python library for importing XDF (Extensible Data Format)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-
-    # The project's main homepage.
-    url='https://github.com/xdf-modules/xdf-Python',
-
-    # Author details
-    author='Christian Kothe',
-    author_email='christian.kothe@intheon.io',
-
-    # Choose your license
-    license='BSD',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    url="https://github.com/xdf-modules/xdf-Python",
+    author="Christian Kothe",
+    author_email="christian.kothe@intheon.io",
+    license="BSD",
     classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: BSD License',
-
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: MacOS',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-
-    # What does your project relate to?
-    keywords=['XDF', 'pyxdf', 'LSL', 'Lab Streaming Layer', 'File Format',
-              'biosignals', 'stream'],
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy'],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
+    keywords=[
+        "XDF",
+        "pyxdf",
+        "LSL",
+        "Lab Streaming Layer",
+        "File Format",
+        "biosignals",
+        "stream",
+    ],
+    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
+    install_requires=["numpy"],
     extras_require={},
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-    # Here we specify all the shared libs for the different platforms, but
-    # setup will probably only find the one library downloaded by the build
-    # script or placed here manually.
     package_data={},
-
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     data_files=[],
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={}
+    entry_points={},
 )


### PR DESCRIPTION
Although we already use `importlib.metadata` (the recommended approach), we only caught `ImportError` when trying to `import pkg_resources`. However, if `setuptools` is installed, `pkg_resources` can still be imported, but raise a `DeprecationWarning`. This PR bumps the minimum required Python version to 3.9, which ships with `importlib.metadata`.