### PR TITLE
Do not package the tests in the bdist/wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "biosignals",
         "stream",
     ],
-    packages=find_packages(exclude=["contrib", "docs", "pyxdf.test*"]),
+    packages=find_packages(exclude=["pyxdf.test*"]),
     install_requires=["numpy"],
     extras_require={},
     package_data={},

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "biosignals",
         "stream",
     ],
-    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
+    packages=find_packages(exclude=["contrib", "docs", "pyxdf.test*"]),
     install_requires=["numpy"],
     extras_require={},
     package_data={},


### PR DESCRIPTION
It seems like this was the intent from the beginning, but the pattern `tests*` in the `excludes` for `find_package` does not match anything. This PR adjusts that pattern to `pyxdf.test*` so that the tests are not unnecessarily included with wheel/binary distributions.

The other two entries, `contrib` and `docs`, could also be removed, since they don’t match anything either.