### PR TITLE
Add clock_times and clock_values to stream dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased] - YYYY-MM-DD
+### Added
+- Add `clock_times` and `clock_values` to stream dictionary ([#105](https://github.com/xdf-modules/pyxdf/pull/105) by [Fabian Grosch](https://github.com/expensne))
+
 ## [1.16.6] - 2024-04-18
 ### Changed
 - Minimum required Python version is now 3.9 ([#100](https://github.com/xdf-modules/xdf-Python/pull/100) by [Clemens Brunner](https://github.com/cbrnr))

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -407,6 +407,8 @@ def load_xdf(
         stream["info"]["effective_srate"] = tmp.effective_srate
         stream["time_series"] = tmp.time_series
         stream["time_stamps"] = tmp.time_stamps
+        stream["clock_times"] = tmp.clock_times
+        stream["clock_values"] = tmp.clock_values
 
     streams = [s for s in streams.values()]
     return streams, fileheader

--- a/pyxdf/test/test_data.py
+++ b/pyxdf/test/test_data.py
@@ -42,6 +42,12 @@ def test_load_file(file):
         np.testing.assert_array_equal(streams[0]["time_series"], s)
         np.testing.assert_array_almost_equal(streams[0]["time_stamps"], t)
 
+        clock_times = np.asarray([6.1, 7.1])
+        clock_values = np.asarray([-.1, -.1])
+
+        np.testing.assert_array_equal(streams[0]["clock_times"], clock_times)
+        np.testing.assert_array_almost_equal(streams[0]["clock_values"], clock_values)
+
         assert streams[1]["info"]["name"][0] == "SendDataString"
         assert streams[1]["info"]["type"][0] == "StringMarker"
         assert streams[1]["info"]["channel_count"][0] == "1"
@@ -66,3 +72,9 @@ def test_load_file(file):
         t = np.array([5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9])
         assert streams[1]["time_series"] == s
         np.testing.assert_array_almost_equal(streams[1]["time_stamps"], t)
+
+        clock_times = np.asarray([])
+        clock_values = np.asarray([])
+
+        np.testing.assert_array_equal(streams[1]["clock_times"], clock_times)
+        np.testing.assert_array_almost_equal(streams[1]["clock_values"], clock_values)


### PR DESCRIPTION
"Clock offsets" are a feature defined in the XDF specification, detailed [here](https://github.com/sccn/xdf/wiki/Specifications#clockoffset-chunk). However, they are not directly accessible when loading XDF contents with pyxdf. These offsets are being used to synchronize clocks within the function `_clock_sync`, as seen [here](https://github.com/xdf-modules/pyxdf/blob/68a00816699f2de7719de3f15b336bbec1fa9bf3/pyxdf/pyxdf.py#L555). Unfortunately, the original values used in these functions are not exposed outside of pyxdf, making it impossible to retrieve them.

When utilizing [LabRecorder](https://github.com/labstreaminglayer/App-LabRecorder), these values are conveniently accessible within the footer, under "info" > "clock_offsets". This accessibility is due to LabRecorder internally storing the original clock offset data, which is then included in the footer. The process of writing the offset data into the specified chunk in the XDF spec can be found [here](https://github.com/labstreaminglayer/App-LabRecorder/blob/becc09e8bf2ff7b83c6b161a55469fa0a898d879/src/recording.cpp#L314C1-L315C1). Notably, the offset data is stored in a vector and later retrieved to populate the footer, as shown [here](https://github.com/labstreaminglayer/App-LabRecorder/blob/becc09e8bf2ff7b83c6b161a55469fa0a898d879/src/recording.cpp#L261).

The redundancy in storing and retrieving offset data appears unnecessary. Hence, I propose exposing the original offset values via the stream dictionary returned by pyxdf. This becomes particularly relevant for us, given that we've developed our own recording software in line with XDF specifications, rather than relying on LabRecorder. Despite this, we're eager to access offset data through pyxdf without resorting to redundant duplication in the footer.