### PR TITLE
FIX: Not looping leading to TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
 - Expose detected segment (used in dejittering) as `stream["info"]["segments"]` ([#117](https://github.com/xdf-modules/pyxdf/pull/117) by [Robert Guggenberger](https://github.com/agricolab))
-- Fix logic of `--loop` argument in `pyxdf.examples.playback_lsl.py`: Supplying `--loop` will loop, whereas ommitting `--loop` will NOT loop ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
+- A non-looping playback of an XDF file will no longer lead to a `TypeError` ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
+
+### Changed
+- Reverse logic of `--loop` argument in `pyxdf.examples.playback_lsl.py` to be more in line with standard practice: Supplying `--loop` will loop, whereas ommitting `--loop` will NOT loop ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
+
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,8 @@
 - A non-looping playback of an XDF file will no longer lead to a `TypeError` ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
 
 ### Changed
-- Reverse logic of `--loop` argument in `pyxdf.examples.playback_lsl.py` to be more in line with standard practice: Supplying `--loop` will loop, whereas ommitting `--loop` will NOT loop ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
-
-
-
-### Changed
 - Rename `pyxdf.examples` module to `pyxdf.cli` ([#118](https://github.com/xdf-modules/xdf-Python/pull/118) by [Clemens Brunner](https://github.com/cbrnr))
+- Reverse logic of `--loop` argument in `pyxdf.examples.playback_lsl.py` to be more in line with standard practice: Supplying `--loop` will loop, whereas ommitting `--loop` will NOT loop ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
 
 ## [1.16.8] - 2024-07-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
 - Expose detected segment (used in dejittering) as `stream["info"]["segments"]` ([#117](https://github.com/xdf-modules/pyxdf/pull/117) by [Robert Guggenberger](https://github.com/agricolab))
+- Fix logic of `--loop` argument in `pyxdf.examples.playback_lsl.py`: Supplying `--loop` will loop, whereas ommitting `--loop` will NOT loop ([#119](https://github.com/xdf-modules/pyxdf/pull/119) by [Stefan Appelhoff](https://github.com/sappelhoff))
+
 
 ### Changed
 - Rename `pyxdf.examples` module to `pyxdf.cli` ([#118](https://github.com/xdf-modules/xdf-Python/pull/118) by [Clemens Brunner](https://github.com/cbrnr))

--- a/pyxdf/cli/playback_lsl.py
+++ b/pyxdf/cli/playback_lsl.py
@@ -224,7 +224,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--playback_speed", type=float, default=1.0, help="Playback speed multiplier."
     )
-    parser.add_argument("--loop", action="store_true", help="Loop playback of the file.")
+    parser.add_argument(
+        "--loop", action="store_true", help="Loop playback of the file."
+    )
     parser.add_argument("--wait_for_consumer", action="store_true")
     args = parser.parse_args()
     main(

--- a/pyxdf/cli/playback_lsl.py
+++ b/pyxdf/cli/playback_lsl.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--playback_speed", type=float, default=1.0, help="Playback speed multiplier."
     )
-    parser.add_argument("--loop", action="store_false")
+    parser.add_argument("--loop", action="store_true", help="Loop playback of the file.")
     parser.add_argument("--wait_for_consumer", action="store_true")
     args = parser.parse_args()
     main(


### PR DESCRIPTION
A flag like `--loop` in this case is typically used as a "true-if-supplied" flag. However, it was instead (~~confusingly~~ counter-intuitively) used as a "false-if-supplied" flag.

This is now fixed. `python -m pyxdf.examples.playback_lsl.py --loop` will loop, whereas not supplying `--loop` will not loop.