### PR TITLE
Segment at negative timestamp breaks

### DIFF
--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -633,7 +633,7 @@ def _jitter_removal(streams, threshold_seconds=1, threshold_samples=500):
         if nsamples > 0 and stream.srate > 0:
             # Identify breaks in the time_stamps
             diffs = np.diff(stream.time_stamps)
-            b_breaks = diffs > np.max(
+            b_breaks = np.abs(diffs) > np.max(
                 (threshold_seconds, threshold_samples * stream.tdiff)
             )
             # find indices (+ 1 to compensate for lost sample in np.diff)

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -625,19 +625,26 @@ def _clock_sync(
     return streams
 
 
-def _jitter_removal(streams, threshold_seconds=1, threshold_samples=500):
+def _detect_breaks(stream, threshold_seconds=1.0, threshold_samples=500):
+    """Detect breaks in the time_stamps of a stream."""
+    # Identify breaks in the time_stamps
+    diffs = np.diff(stream.time_stamps)
+    b_breaks = np.abs(diffs) > np.max(
+        (threshold_seconds, threshold_samples * stream.tdiff)
+    )
+    # find indices (+ 1 to compensate for lost sample in np.diff)
+    break_inds = np.where(b_breaks)[0] + 1
+    return break_inds
+
+
+def _jitter_removal(streams, threshold_seconds=1.0, threshold_samples=500):
     for stream_id, stream in streams.items():
         stream.effective_srate = 0  # will be recalculated if possible
         nsamples = len(stream.time_stamps)
         stream.segments = []
         if nsamples > 0 and stream.srate > 0:
-            # Identify breaks in the time_stamps
-            diffs = np.diff(stream.time_stamps)
-            b_breaks = np.abs(diffs) > np.max(
-                (threshold_seconds, threshold_samples * stream.tdiff)
-            )
-            # find indices (+ 1 to compensate for lost sample in np.diff)
-            break_inds = np.where(b_breaks)[0] + 1
+            # find break indices
+            break_inds = _detect_breaks(stream, threshold_seconds, threshold_samples)
 
             # Get indices delimiting segments without breaks
             # 0th sample is a segment start and last sample is a segment stop

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -629,8 +629,8 @@ def _detect_breaks(stream, threshold_seconds=1.0, threshold_samples=500):
     """Detect breaks in the time_stamps of a stream."""
     # Identify breaks in the time_stamps
     diffs = np.diff(stream.time_stamps)
-    b_breaks = np.abs(diffs) > np.max(
-        (threshold_seconds, threshold_samples * stream.tdiff)
+    b_breaks = (diffs <= 0) | (
+        diffs > np.max((threshold_seconds, threshold_samples * stream.tdiff))
     )
     # find indices (+ 1 to compensate for lost sample in np.diff)
     break_inds = np.where(b_breaks)[0] + 1

--- a/test/test_jitter_removal.py
+++ b/test/test_jitter_removal.py
@@ -1,4 +1,3 @@
-import pytest
 from pyxdf.pyxdf import _detect_breaks
 
 
@@ -8,44 +7,105 @@ class MockStreamData:
         self.tdiff = tdiff
 
 
-def test_detect_no_breaks():
+def test_detect_no_breaks_seconds():
     timestamps = list(range(-5, 5))
     stream = MockStreamData(timestamps, 1)
-    # if diff > 2 and larger 500 * tdiff -> 0
-    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=500)
+    # if diff > 2 and larger 0 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=0)
     assert breaks.size == 0
-    # if diff > 0.1 and larger 1 * tdiff -> 0
-    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=1)
+    # if diff > 1 and larger 0 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
     assert breaks.size == 0
 
 
-def test_detect_breaks_reverse():
-    timestamps = list(reversed(range(-5, 5)))
+def test_detect_no_breaks_samples():
+    timestamps = list(range(-5, 5))
     stream = MockStreamData(timestamps, 1)
+    # if diff > 0 and larger 2 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=2)
+    assert breaks.size == 0
+    # if diff > 0 and larger 1 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=1)
+    assert breaks.size == 0
+
+
+def test_detect_breaks_seconds():
+    timestamps = list(range(-5, 5, 2))
+    stream = MockStreamData(timestamps, 1)
+    # if diff > 1 and larger 0 * tdiff -> 4
     breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
+
+
+def test_detect_breaks_samples():
+    timestamps = list(range(-5, 5, 2))
+    stream = MockStreamData(timestamps, 1)
+    # if diff > 0 and larger 1 * tdiff -> 4
+    breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=1)
     assert breaks.size == len(timestamps) - 1
 
 
 def test_detect_breaks_gap_in_negative():
     timestamps = [-4, 1, 2, 3, 4]
     stream = MockStreamData(timestamps, 1)
+    # if diff > 1 and larger 1 * tdiff -> 1
     breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
     assert breaks.size == 1
     assert breaks[0] == 1
     timestamps = [-4, -2, -1, 0, 1, 2, 3, 4]
     stream = MockStreamData(timestamps, 1)
+    # if diff > 1 and larger 1 * tdiff -> 1
     breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
     assert breaks.size == 1
     assert breaks[0] == 1
+    # if diff > 0.1 and larger 0 * tdiff -> 7
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
 
 
 def test_detect_breaks_gap_in_positive():
     timestamps = [1, 3, 4, 5, 6]
     stream = MockStreamData(timestamps, 1)
-    # if diff > 1 and larger 1 * tdiff -> 1 -> 1
+    # if diff > 1 and larger 1 * tdiff -> 1
     breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
     assert breaks.size == 1
     assert breaks[0] == 1
-    # if diff > 0.1 and larger 0 * tdiff ->
+    # if diff > 0.1 and larger 0 * tdiff -> 4
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
+
+
+def test_detect_breaks_reverse():
+    timestamps = list(reversed(range(-5, 5)))
+    stream = MockStreamData(timestamps, 1)
+    # if diff <= 0 -> 9
+    breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
+
+
+def test_detect_breaks_gaps_non_monotonic():
+    timestamps = [-4, 1, -3, -2, -1, 1, 5, 1, 2]
+    stream = MockStreamData(timestamps, 1)
+    # if diff <= 0 or diff > 1 and larger 1 * tdiff -> 5
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert list(breaks) == [1, 2, 5, 6, 7]
+    # if diff <= 0 or diff > 2 and larger 1 * tdiff -> 4
+    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=1)
+    assert list(breaks) == [1, 2, 6, 7]
+    # if diff <= 0 or diff > 0.1 and larger 0 * tdiff -> 8
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
+
+
+def test_detect_breaks_strict_non_monotonic():
+    timestamps = [-4, -5, -3, -2, -1, 0, 0, 1, 2]
+    stream = MockStreamData(timestamps, 1)
+    # if diff <= 0 or diff > 1 and larger 1 * tdiff -> 3
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert list(breaks) == [1, 2, 6]
+    # if diff <= 0 or diff > 2 and larger 2 * tdiff -> 2
+    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=2)
+    assert list(breaks) == [1, 6]
+    # if diff <= 0 or diff > 0.1 and larger 0 * tdiff -> 8
     breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
     assert breaks.size == len(timestamps) - 1

--- a/test/test_jitter_removal.py
+++ b/test/test_jitter_removal.py
@@ -1,10 +1,19 @@
-from pyxdf.pyxdf import _detect_breaks
+import numpy as np
+from pyxdf.pyxdf import _detect_breaks, _ensure_sorted
 
 
 class MockStreamData:
-    def __init__(self, time_stamps, tdiff):
-        self.time_stamps = time_stamps
+    def __init__(self, time_stamps, tdiff, fmt="float32"):
+        self.time_stamps = np.array(time_stamps)
         self.tdiff = tdiff
+        self.fmt = fmt
+        if fmt == "string":
+            self.time_series = [str(x) for x in time_stamps]
+        else:
+            self.time_series = np.array(time_stamps, dtype=fmt)
+
+
+# Monotonic timeseries data.
 
 
 def test_detect_no_breaks_seconds():
@@ -33,7 +42,7 @@ def test_detect_breaks_seconds():
     timestamps = list(range(-5, 5, 2))
     stream = MockStreamData(timestamps, 1)
     # if diff > 1 and larger 0 * tdiff -> 4
-    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
     assert breaks.size == len(timestamps) - 1
 
 
@@ -75,37 +84,53 @@ def test_detect_breaks_gap_in_positive():
     assert breaks.size == len(timestamps) - 1
 
 
+# Non-monotonic timeseries data.
+
+
 def test_detect_breaks_reverse():
     timestamps = list(reversed(range(-5, 5)))
     stream = MockStreamData(timestamps, 1)
-    # if diff <= 0 -> 9
-    breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=0)
-    assert breaks.size == len(timestamps) - 1
+    stream = _ensure_sorted(1, stream)
+    # Timeseries should now also be sorted.
+    assert np.all(stream.time_series == sorted(timestamps))
+    # if diff > 1 and larger 0 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
+    assert breaks.size == 0
 
 
-def test_detect_breaks_gaps_non_monotonic():
-    timestamps = [-4, 1, -3, -2, -1, 1, 5, 1, 2]
+def test_detect_breaks_non_monotonic_num():
+    timestamps = [-4, -5, -3, -2, 0, 0, 1, 2]
     stream = MockStreamData(timestamps, 1)
-    # if diff <= 0 or diff > 1 and larger 1 * tdiff -> 5
+    stream = _ensure_sorted(1, stream)
+    # Timeseries data should now also be sorted.
+    assert np.all(stream.time_series == sorted(timestamps))
+    # if diff > 1 and larger 1 * tdiff -> 1
     breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
-    assert list(breaks) == [1, 2, 5, 6, 7]
-    # if diff <= 0 or diff > 2 and larger 1 * tdiff -> 4
-    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=1)
-    assert list(breaks) == [1, 2, 6, 7]
-    # if diff <= 0 or diff > 0.1 and larger 0 * tdiff -> 8
-    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
-    assert breaks.size == len(timestamps) - 1
-
-
-def test_detect_breaks_strict_non_monotonic():
-    timestamps = [-4, -5, -3, -2, -1, 0, 0, 1, 2]
-    stream = MockStreamData(timestamps, 1)
-    # if diff <= 0 or diff > 1 and larger 1 * tdiff -> 3
-    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
-    assert list(breaks) == [1, 2, 6]
-    # if diff <= 0 or diff > 2 and larger 2 * tdiff -> 2
+    assert breaks.size == 1
+    assert breaks[0] == 4
+    # if diff > 2 and larger 2 * tdiff -> 0
     breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=2)
-    assert list(breaks) == [1, 6]
-    # if diff <= 0 or diff > 0.1 and larger 0 * tdiff -> 8
+    assert breaks.size == 0
+    # if diff > 0.1 and larger 0 * tdiff -> 6
     breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
-    assert breaks.size == len(timestamps) - 1
+    assert breaks.size == len(timestamps) - 2
+    assert list(breaks) == [1, 2, 3, 4, 6, 7]
+
+
+def test_detect_breaks_non_monotonic_str():
+    timestamps = [-4, -5, -3, -2, 0, 0, 1, 2]
+    stream = MockStreamData(timestamps, 1, "string")
+    stream = _ensure_sorted(1, stream)
+    # Timeseries data should now also be sorted.
+    assert np.all(stream.time_series == [str(x) for x in sorted(timestamps)])
+    # if diff > 1 and larger 1 * tdiff -> 1
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert breaks.size == 1
+    assert breaks[0] == 4
+    # if diff > 2 and larger 2 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=2)
+    assert breaks.size == 0
+    # if diff > 0.1 and larger 0 * tdiff -> 6
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 2
+    assert list(breaks) == [1, 2, 3, 4, 6, 7]

--- a/test/test_jitter_removal.py
+++ b/test/test_jitter_removal.py
@@ -1,0 +1,51 @@
+import pytest
+from pyxdf.pyxdf import _detect_breaks
+
+
+class MockStreamData:
+    def __init__(self, time_stamps, tdiff):
+        self.time_stamps = time_stamps
+        self.tdiff = tdiff
+
+
+def test_detect_no_breaks():
+    timestamps = list(range(-5, 5))
+    stream = MockStreamData(timestamps, 1)
+    # if diff > 2 and larger 500 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=2, threshold_samples=500)
+    assert breaks.size == 0
+    # if diff > 0.1 and larger 1 * tdiff -> 0
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=1)
+    assert breaks.size == 0
+
+
+def test_detect_breaks_reverse():
+    timestamps = list(reversed(range(-5, 5)))
+    stream = MockStreamData(timestamps, 1)
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1
+
+
+def test_detect_breaks_gap_in_negative():
+    timestamps = [-4, 1, 2, 3, 4]
+    stream = MockStreamData(timestamps, 1)
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert breaks.size == 1
+    assert breaks[0] == 1
+    timestamps = [-4, -2, -1, 0, 1, 2, 3, 4]
+    stream = MockStreamData(timestamps, 1)
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert breaks.size == 1
+    assert breaks[0] == 1
+
+
+def test_detect_breaks_gap_in_positive():
+    timestamps = [1, 3, 4, 5, 6]
+    stream = MockStreamData(timestamps, 1)
+    # if diff > 1 and larger 1 * tdiff -> 1 -> 1
+    breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=1)
+    assert breaks.size == 1
+    assert breaks[0] == 1
+    # if diff > 0.1 and larger 0 * tdiff ->
+    breaks = _detect_breaks(stream, threshold_seconds=0.1, threshold_samples=0)
+    assert breaks.size == len(timestamps) - 1


### PR DESCRIPTION
When dejittering, also take into account negative timestamps when
determining segment boundaries.