### PR TITLE
Fix clock sync/clock resets indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
 - Add new `case_sensitive` parameter to `match_streaminfos`, defaulting to `False` to maintain previous behavior; when `False`, stream properties are matched more leniently ([#134](https://github.com/xdf-modules/pyxdf/pull/134) by [Stefan Appelhoff](https://github.com/sappelhoff))
+- Expose detected clock segments (used in synchronisation) as `stream["info"]["clock_segments"]` ([#131](https://github.com/xdf-modules/pyxdf/pull/131) by [Jamie Forth](https://github.com/jamieforth))
 
 ### Changed
 - Segment at negative time intervals when dejittering ([#130](https://github.com/xdf-modules/pyxdf/pull/130) by [Jamie Forth](https://github.com/jamieforth))
+- Handle `LinAlgError` (with warning) during synchronisation ([#131](https://github.com/xdf-modules/pyxdf/pull/131) by [Jamie Forth](https://github.com/jamieforth))
 
 ### Fixed
 - Ensure empty stream segments are initialised ([#129](https://github.com/xdf-modules/pyxdf/pull/129) by [Jamie Forth](https://github.com/jamieforth))
 - Uniformly calculate effective sample rate as `(len(time_stamps) - 1) / duration` ([#129](https://github.com/xdf-modules/pyxdf/pull/129) by [Jamie Forth](https://github.com/jamieforth))
+- Fix synchronisation for streams with clock resets and MAD calculation used in clock value segmentation ([#131](https://github.com/xdf-modules/pyxdf/pull/131) by [Jamie Forth](https://github.com/jamieforth))
 
 ## [1.17.0] - 2025-01-07
 ### Fixed

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -376,11 +376,10 @@ def load_xdf(
         )
     else:
         for stream in temp.values():
-            if len(stream.time_stamps) > 1:
+            # initialize effective_srate in case jitter_removal was not selected
+            if stream.srate != 0 and len(stream.time_stamps) > 1:
                 duration = stream.time_stamps[-1] - stream.time_stamps[0]
                 stream.effective_srate = (len(stream.time_stamps) - 1) / duration
-            else:
-                stream.effective_srate = 0.0
             # initialize segment list in case jitter_removal was not selected
             if len(stream.time_stamps) > 0:
                 stream.segments.append((0, len(stream.time_stamps) - 1))  # inclusive
@@ -695,8 +694,9 @@ def _jitter_removal(streams, threshold_seconds=1, threshold_samples=500):
             # Recalculate effective_srate if possible
             counts = (stop_idx + 1) - start_idx
             if np.any(counts > 1):
-                # Calculate range segment duration
+                # Calculate segment durations
                 durations = stream.time_stamps[stop_idx] - stream.time_stamps[start_idx]
+                # Calculate effective srate as weighted mean
                 stream.effective_srate = np.sum(counts - 1) / np.sum(durations)
 
             srate, effective_srate = stream.srate, stream.effective_srate

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -573,6 +573,9 @@ def _detect_clock_resets(
     # hot-swapped during an ongoing recording, or the clock was reset
     # otherwise.
 
+    if len(stream.clock_times) <= 1:
+        raise ValueError("Two or more clock offsets are required for reset detection")
+
     clock_times = stream.clock_times
     clock_values = stream.clock_values
     time_diff = np.diff(clock_times)

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -596,14 +596,9 @@ def _detect_clock_resets(
     value_glitch = cond1 | (cond2 & cond3)
     resets_at = time_glitch & value_glitch
 
-    # Determine the [start,end] index ranges between resets
-    if not any(resets_at):
-        ranges = [(0, len(clock_times) - 1)]
-    else:
-        indices = np.where(resets_at)[0]
-        indices = np.hstack((0, indices + 1, indices, len(resets_at)))
-        ranges = np.reshape(indices, (2, -1)).T
-    return ranges
+    # Determine segments: [start,end] index ranges between resets (inclusive)
+    segments = _find_segment_indices(resets_at)[0]
+    return segments
 
 
 def _clock_sync(

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -601,7 +601,7 @@ def _detect_clock_resets(
         ranges = [(0, len(clock_times) - 1)]
     else:
         indices = np.where(resets_at)[0]
-        indices = np.hstack((0, indices, indices + 1, len(resets_at) - 1))
+        indices = np.hstack((0, indices + 1, indices, len(resets_at)))
         ranges = np.reshape(indices, (2, -1)).T
     return ranges
 

--- a/test/mock_data_stream.py
+++ b/test/mock_data_stream.py
@@ -110,3 +110,4 @@ class MockStreamData:
             if len(clock_times) != len(clock_values):
                 raise ValueError("Clock times and values must be the same length")
         self.segments = []
+        self.clock_segments = []

--- a/test/test_clock_sync.py
+++ b/test/test_clock_sync.py
@@ -1,9 +1,10 @@
+import logging
+
 import numpy as np
 import pytest
 from pyxdf.pyxdf import _clock_sync
 
 from mock_data_stream import MockStreamData
-
 
 # No clock resets
 
@@ -170,6 +171,86 @@ def test_sync_no_resets_bounds_jitter(
     np.testing.assert_equal(streams[1].clock_times, clock_times)
     np.testing.assert_equal(streams[1].clock_values, clock_values)
     np.testing.assert_equal(streams[1].clock_segments, [(0, len(time_stamps) - 1)])
+
+
+# Invalid clock offsets: LinAlgError
+
+
+def test_clock_sync_error_keep_segment(caplog):
+    caplog.set_level(logging.WARNING)
+    expected = [0, 1, 2, 3, 4] + [15, 16, 17, 18, 19]
+    time_stamps = np.arange(0, len(expected))
+    # Clock offsets (0, 1) are unusable: LinAlgError
+    clock_times = [0, 0] + [10, 15]
+    clock_values = [0, 0] + [10, 10]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        reset_threshold_stds=0,
+        reset_threshold_seconds=4,
+        reset_threshold_offset_stds=0,
+        reset_threshold_offset_seconds=9,
+    )
+    assert "Clock offsets (0, 1) cannot be used for synchronization" in caplog.text
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+    np.testing.assert_equal(
+        streams[1].clock_segments,
+        [
+            (0, 4),
+            (5, 9),
+        ],
+    )
+
+
+def test_clock_sync_error_skip_segment(caplog):
+    caplog.set_level(logging.WARNING)
+    expected = [15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+    # All time-stamps should be synchronized by clock offsets (2, 3)
+    time_stamps = np.arange(5, 5 + len(expected))
+    # Clock offsets (0, 1) are unusable: LinAlgError
+    clock_times = [0, 0] + [10, 15]
+    clock_values = [0, 0] + [10, 10]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        reset_threshold_stds=0,
+        reset_threshold_seconds=4,
+        reset_threshold_offset_stds=0,
+        reset_threshold_offset_seconds=9,
+    )
+    assert "Clock offsets (0, 1) cannot be used for synchronization" in caplog.text
+    assert "No samples in clock offsets (0, 1), skipping..." in caplog.text
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+    np.testing.assert_equal(
+        streams[1].clock_segments,
+        [
+            (0, 9),
+        ],
+    )
 
 
 # Clock resets

--- a/test/test_clock_sync.py
+++ b/test/test_clock_sync.py
@@ -166,3 +166,270 @@ def test_sync_no_resets_bounds_jitter(
     np.testing.assert_equal(streams[1].clock_times, clock_times)
     np.testing.assert_equal(streams[1].clock_values, clock_values)
 
+
+# Clock resets
+
+
+def test_sync_clock_jumps_forward_break_at_reset():
+    expected = [0, 1, 2, 3, 4] + [5, 6, 7, 8, 9]
+    # Time-stamps within clock regions
+    time_stamps = [1, 2, 3, 4, 5] + [17, 18, 19, 20, 21]
+    clock_times = [1, 6, 17, 22]
+    clock_values = [-1, -1, -12, -12]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+
+
+def test_sync_clock_jumps_forward_break_between_reset():
+    expected = [3, 4, 5, 6, 7, 8, 9, 10] + [9, 10, 11, 12, 13, 14, 15, 16]
+    # Time-stamps between clock regions
+    time_stamps = [4, 5, 6, 7, 8, 9, 10, 11] + [12, 13, 14, 15, 16, 17, 18, 19]
+    clock_times = [1, 6, 17, 22]
+    clock_values = [-1, -1, -3, -3]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+
+
+def test_sync_clock_jumps_backward_break_at_reset():
+    expected = [5, 6, 7, 8, 9] + [10, 11, 12, 13, 14]
+    # Time-stamps within clock regions
+    time_stamps = [17, 18, 19, 20, 21] + [1, 2, 3, 4, 5]
+    clock_times = [17, 22, 1, 6]
+    clock_values = [-12, -12, 9, 9]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+
+
+def test_sync_clock_jumps_backward_break_between_reset():
+    expected = [5, 6, 7, 8, 9, 10, 11, 12] + [10, 11, 12, 13, 14, 15, 16, 17]
+    # Time-stamps between clock regions
+    time_stamps = [17, 18, 19, 20, 21, 22, 23, 24] + [1, 2, 3, 4, 5, 6, 7, 8]
+    clock_times = [17, 22, 1, 6]
+    clock_values = [-12, -12, 9, 9]
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+
+
+@pytest.mark.parametrize(
+    "clock_offsets",
+    [
+        ((0, 1), (3, 4)),
+        ((0, 3), (5, 8)),
+        ((0, 4), (6, 10), (12, 16)),
+    ],
+)
+@pytest.mark.parametrize("tdiff", [1, 1 / 10, 1 / 100])
+@pytest.mark.parametrize("clock_tdiff", [5, 10])
+def test_sync_clock_jumps_forward_tdiffs(clock_offsets, tdiff, clock_tdiff):
+    offsets_per_range = [(end - start) + 1 for start, end in clock_offsets]
+    clock_reset_times = [
+        (
+            start * clock_tdiff,
+            (end + 1) * clock_tdiff,
+        )
+        for start, end in clock_offsets
+    ]
+    clock_times = [
+        t
+        for start, end in clock_reset_times
+        for t in range(
+            start,
+            end,
+            clock_tdiff,
+        )
+    ]
+    clock_values = np.repeat(
+        [-start for start, _ in clock_reset_times], offsets_per_range
+    ).tolist()
+    time_stamps = np.hstack(
+        [np.arange(start, stop, tdiff) for start, stop in clock_reset_times]
+    )
+    expected = np.hstack(
+        [np.arange(0, clock_tdiff * offsets, tdiff) for offsets in offsets_per_range]
+    )
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        reset_threshold_seconds=clock_tdiff - 1,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize(
+    "clock_offsets",
+    [
+        ((3, 4), (0, 1)),
+        ((5, 8), (0, 3)),
+        ((12, 16), (6, 10), (0, 4)),
+    ],
+)
+@pytest.mark.parametrize("tdiff", [1, 1 / 10, 1 / 100])
+@pytest.mark.parametrize("clock_tdiff", [5, 10])
+def test_sync_clock_jumps_backward_tdiffs(clock_offsets, tdiff, clock_tdiff):
+    offsets_per_range = [(end - start) + 1 for start, end in clock_offsets]
+    clock_reset_times = [
+        (
+            start * clock_tdiff,
+            (end + 1) * clock_tdiff,
+        )
+        for start, end in clock_offsets
+    ]
+    clock_times = [
+        t
+        for start, end in clock_reset_times
+        for t in range(
+            start,
+            end,
+            clock_tdiff,
+        )
+    ]
+    clock_values = np.repeat(
+        [-start for start, _ in clock_reset_times], offsets_per_range
+    ).tolist()
+    time_stamps = np.hstack(
+        [np.arange(start, stop, tdiff) for start, stop in clock_reset_times]
+    )
+    expected = np.hstack(
+        [np.arange(0, clock_tdiff * offsets, tdiff) for offsets in offsets_per_range]
+    )
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize(
+    "clock_offsets",
+    [
+        ((3, 4), (0, 1), (3, 4)),
+        ((5, 8), (0, 3), (5, 8)),
+        ((12, 16), (6, 10), (0, 4), (6, 10), (12, 16)),
+    ],
+)
+@pytest.mark.parametrize("tdiff", [1, 1 / 10, 1 / 100])
+@pytest.mark.parametrize("clock_tdiff", [5, 10])
+def test_sync_clock_jumps_forward_backward_tdiffs(clock_offsets, tdiff, clock_tdiff):
+    offsets_per_range = [(end - start) + 1 for start, end in clock_offsets]
+    clock_reset_times = [
+        (
+            start * clock_tdiff,
+            (end + 1) * clock_tdiff,
+        )
+        for start, end in clock_offsets
+    ]
+    clock_times = [
+        t
+        for start, end in clock_reset_times
+        for t in range(
+            start,
+            end,
+            clock_tdiff,
+        )
+    ]
+    clock_values = np.repeat(
+        [-start for start, _ in clock_reset_times], offsets_per_range
+    ).tolist()
+    time_stamps = np.hstack(
+        [np.arange(start, stop, tdiff) for start, stop in clock_reset_times]
+    )
+    expected = np.hstack(
+        [np.arange(0, clock_tdiff * offsets, tdiff) for offsets in offsets_per_range]
+    )
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        reset_threshold_seconds=clock_tdiff - 1,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        expected,
+        atol=1e-13,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)

--- a/test/test_clock_sync.py
+++ b/test/test_clock_sync.py
@@ -1,0 +1,168 @@
+import numpy as np
+import pytest
+from pyxdf.pyxdf import _clock_sync
+
+from mock_data_stream import MockStreamData
+
+
+# No clock resets
+
+
+@pytest.mark.parametrize("n_clock_offsets", list(range(0, 5)))
+@pytest.mark.parametrize("handle_clock_resets", [True, False])
+def test_sync_empty_stream(n_clock_offsets, handle_clock_resets):
+    time_stamps = []
+    clock_tdiff = 5
+    duration = n_clock_offsets * clock_tdiff
+    clock_times = list(range(0, duration, clock_tdiff))
+    clock_values = [0] * n_clock_offsets
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        handle_clock_resets=handle_clock_resets,
+    )
+    np.testing.assert_equal(streams[1].time_stamps, time_stamps)
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize("n_time_stamps", list(range(0, 5)))
+@pytest.mark.parametrize("handle_clock_resets", [True, False])
+def test_sync_empty_offsets(n_time_stamps, handle_clock_resets):
+    tdiff = 1
+    time_stamps = list(range(0, n_time_stamps, tdiff))
+    clock_times = []
+    clock_values = []
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        handle_clock_resets=handle_clock_resets,
+    )
+    np.testing.assert_equal(streams[1].time_stamps, time_stamps)
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize("n_clock_offsets", list(range(2, 5)))
+@pytest.mark.parametrize("clock_value", list(range(-10, 11, 5)))
+@pytest.mark.parametrize("handle_clock_resets", [True, False])
+def test_sync_no_resets(n_clock_offsets, clock_value, handle_clock_resets):
+    tdiff = 1
+    clock_tdiff = 5
+    duration = (n_clock_offsets - 1) * clock_tdiff
+    time_stamps = np.arange(0, duration, tdiff)
+    # Clock offsets cover the full duration of time-stamps
+    clock_times = list(range(0, duration + tdiff, clock_tdiff))
+    clock_values = [clock_value] * len(clock_times)
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        handle_clock_resets=handle_clock_resets,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        time_stamps + clock_value,
+        atol=1e-14,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize("n_clock_offsets", list(range(2, 4)))
+@pytest.mark.parametrize("clock_value", list(range(-10, 11, 5)))
+@pytest.mark.parametrize("handle_clock_resets", [True, False])
+def test_sync_no_resets_bounds(n_clock_offsets, clock_value, handle_clock_resets):
+    tdiff = 1
+    clock_tdiff = 5
+    duration = n_clock_offsets * clock_tdiff
+    # Time-stamps extend 5 seconds before and after clock offsets
+    time_stamps = np.arange(-clock_tdiff, duration, tdiff)
+    clock_times = list(range(0, duration, clock_tdiff))
+    clock_values = [clock_value] * len(clock_times)
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        handle_clock_resets=handle_clock_resets,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        time_stamps + clock_value,
+        atol=1e-14,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+
+
+@pytest.mark.parametrize("n_clock_offsets", list(range(2, 4)))
+@pytest.mark.parametrize("clock_value", list(range(-10, 11, 5)))
+@pytest.mark.parametrize("handle_clock_resets", [True, False])
+def test_sync_no_resets_bounds_jitter(
+    n_clock_offsets, clock_value, handle_clock_resets
+):
+    tdiff = 1
+    clock_tdiff = 5
+    duration = n_clock_offsets * clock_tdiff
+    # Time-stamps extend 5 seconds before and after clock offsets
+    time_stamps = np.hstack(
+        [
+            np.arange(-clock_tdiff, 0, tdiff),
+            np.zeros(duration),
+            np.arange(1, clock_tdiff + tdiff, tdiff),
+        ]
+    )
+    jit_std = 0.0001
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration, clock_tdiff)
+    clock_times = (
+        clock_times + rng.standard_normal(len(clock_times)) * jit_std
+    ).tolist()
+    clock_values = clock_value + rng.standard_normal(n_clock_offsets) * jit_std
+    clock_values = clock_values.tolist()
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+            clock_values=clock_values,
+        )
+    }
+    _clock_sync(
+        streams,
+        handle_clock_resets=handle_clock_resets,
+    )
+    np.testing.assert_allclose(
+        streams[1].time_stamps,
+        time_stamps + clock_value,
+        atol=1e-3,
+    )
+    np.testing.assert_equal(streams[1].time_series[:, 0], time_stamps)
+    np.testing.assert_equal(streams[1].clock_times, clock_times)
+    np.testing.assert_equal(streams[1].clock_values, clock_values)
+

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -194,6 +194,134 @@ def test_minimal_file_segments(jitter_break_threshold_seconds):
 
 @pytest.mark.parametrize("dejitter_timestamps", [False, True])
 @pytest.mark.parametrize("synchronize_clocks", [False, True])
+@pytest.mark.skipif("clock_resets" not in files, reason="File not found.")
+def test_clock_resets_file(synchronize_clocks, dejitter_timestamps):
+    path = files["clock_resets"]
+    streams, header = load_xdf(
+        path,
+        synchronize_clocks=synchronize_clocks,
+        dejitter_timestamps=dejitter_timestamps,
+    )
+
+    assert header["info"]["version"][0] == "1.0"
+
+    assert len(streams) == 2
+
+    # Stream ID: 1
+    i = 0
+    assert streams[i]["info"]["name"][0] == "MyMarkerStream"
+    assert streams[i]["info"]["type"][0] == "Markers"
+    assert streams[i]["info"]["channel_count"][0] == "1"
+    assert streams[i]["info"]["nominal_srate"][0] == "0"
+    assert streams[i]["info"]["channel_format"][0] == "string"
+    assert streams[i]["info"]["source_id"][0] == "myuidw43536"
+    assert streams[i]["info"]["version"][0] == "1.1000000000000001"
+    assert streams[i]["info"]["created_at"][0] == "564076.02850699995"
+    assert streams[i]["info"]["uid"][0] == "1efcb4a6-8894-4014-b404-4b6f6b2205f2"
+    assert streams[i]["info"]["session_id"][0] == "default"
+    assert streams[i]["info"]["hostname"][0] == "BP-LP-022"
+    assert streams[i]["info"]["v4address"][0] is None
+    assert streams[i]["info"]["v4data_port"][0] == "16572"
+    assert streams[i]["info"]["v4service_port"][0] == "16572"
+    assert streams[i]["info"]["v6address"][0] is None
+    assert streams[i]["info"]["v6data_port"][0] == "16572"
+    assert streams[i]["info"]["v6service_port"][0] == "16572"
+
+    # Info added by pyxdf
+    assert streams[i]["info"]["stream_id"] == 1
+    assert streams[i]["info"]["effective_srate"] == 0
+    assert streams[i]["info"]["segments"] == [(0, 174)]
+    assert streams[i]["info"]["clock_segments"] == (
+        [(0, 90), (91, 174)] if synchronize_clocks else []
+    )
+
+    # Footer
+    assert streams[i]["footer"]["info"]["first_timestamp"][0] == "653153.2121885"
+    assert streams[i]["footer"]["info"]["last_timestamp"][0] == "259.6538279"
+    assert streams[i]["footer"]["info"]["sample_count"][0] == "175"
+    first_clock_offset = streams[i]["footer"]["info"]["clock_offsets"][0]["offset"][0]
+    assert first_clock_offset["time"][0] == "653156.02616855"
+    assert first_clock_offset["value"][0] == "-652340.2838639501"
+    last_clock_offset = streams[i]["footer"]["info"]["clock_offsets"][0]["offset"][-1]
+    assert last_clock_offset["time"][0] == "264.6430016000002"
+    assert last_clock_offset["value"][0] == "1121.165595"
+
+    # Clock offsets: Test against footer
+    assert streams[i]["clock_times"][0] == pytest.approx(
+        float(first_clock_offset["time"][0]), abs=1e-6
+    )
+    assert streams[i]["clock_values"][0] == pytest.approx(
+        float(first_clock_offset["value"][0]), abs=1e-4
+    )
+    assert streams[i]["clock_times"][-1] == pytest.approx(
+        float(last_clock_offset["time"][0]), abs=1e-6
+    )
+    assert streams[i]["clock_values"][-1] == pytest.approx(
+        float(last_clock_offset["value"][0]), abs=1e-4
+    )
+
+    # Stream ID: 2
+    i = 1
+    assert streams[i]["info"]["name"][0] == "BioSemi"
+    assert streams[i]["info"]["type"][0] == "EEG"
+    assert streams[i]["info"]["channel_count"][0] == "8"
+    assert streams[i]["info"]["nominal_srate"][0] == "100"
+    assert streams[i]["info"]["channel_format"][0] == "float32"
+    assert streams[i]["info"]["source_id"][0] == "myuid34234"
+    assert streams[i]["info"]["version"][0] == "1.1000000000000001"
+    assert streams[i]["info"]["created_at"][0] == "653103.26692229998"
+    assert streams[i]["info"]["uid"][0] == "fa3e14ab-b621-480e-a9d5-c740f0e47140"
+    assert streams[i]["info"]["session_id"][0] == "default"
+    assert streams[i]["info"]["hostname"][0] == "BP-LP-022"
+    assert streams[i]["info"]["v4address"][0] is None
+    assert streams[i]["info"]["v4data_port"][0] == "16573"
+    assert streams[i]["info"]["v4service_port"][0] == "16573"
+    assert streams[i]["info"]["v6address"][0] is None
+    assert streams[i]["info"]["v6data_port"][0] == "16573"
+    assert streams[i]["info"]["v6service_port"][0] == "16573"
+
+    # Info added by pyxdf
+    assert streams[i]["info"]["stream_id"] == 2
+    if dejitter_timestamps:
+        assert streams[i]["info"]["effective_srate"] == pytest.approx(92.934, abs=1e-3)
+        assert streams[i]["info"]["segments"] == [(0, 12875), (12876, 27814)]
+    else:
+        # Effective srate will be incorrect.
+        assert streams[i]["info"]["effective_srate"] != pytest.approx(92.934, abs=1e-3)
+        assert streams[i]["info"]["segments"] == [(0, 27814)]
+
+    assert streams[i]["info"]["clock_segments"] == (
+        [(0, 12875), (12876, 27814)] if synchronize_clocks else []
+    )
+
+    # Footer
+    assert streams[i]["footer"]["info"]["first_timestamp"][0] == "653150.379117"
+    assert streams[i]["footer"]["info"]["last_timestamp"][0] == "261.9267033"
+    assert streams[i]["footer"]["info"]["sample_count"][0] == "27815"
+    first_clock_offset = streams[i]["footer"]["info"]["clock_offsets"][0]["offset"][0]
+    assert first_clock_offset["time"][0] == "653156.0261441499"
+    assert first_clock_offset["value"][0] == "-652340.28383985"
+    last_clock_offset = streams[i]["footer"]["info"]["clock_offsets"][0]["offset"][-1]
+    assert last_clock_offset["time"][0] == "264.6385764000001"
+    assert last_clock_offset["value"][0] == "1121.1656319"
+
+    # Clock offsets: Test against footer
+    assert streams[i]["clock_times"][0] == pytest.approx(
+        float(first_clock_offset["time"][0]), abs=1e-6
+    )
+    assert streams[i]["clock_values"][0] == pytest.approx(
+        float(first_clock_offset["value"][0]), abs=1e-4
+    )
+    assert streams[i]["clock_times"][-1] == pytest.approx(
+        float(last_clock_offset["time"][0]), abs=1e-6
+    )
+    assert streams[i]["clock_values"][-1] == pytest.approx(
+        float(last_clock_offset["value"][0]), abs=1e-4
+    )
+
+
+@pytest.mark.parametrize("dejitter_timestamps", [False, True])
+@pytest.mark.parametrize("synchronize_clocks", [False, True])
 @pytest.mark.skipif("empty_streams" not in files, reason="File not found.")
 def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     path = files["empty_streams"]

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -65,6 +65,9 @@ def test_minimal_file(synchronize_clocks):
     assert streams[i]["info"]["stream_id"] == 0
     assert streams[i]["info"]["effective_srate"] == pytest.approx(10)
     assert streams[i]["info"]["segments"] == [(0, 8)]
+    assert streams[i]["info"]["clock_segments"] == (
+        [(0, 8)] if synchronize_clocks else []
+    )
 
     # Footer
     assert streams[i]["footer"]["info"]["first_timestamp"][0] == "5.1"
@@ -230,6 +233,9 @@ def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     assert streams[i]["info"]["stream_id"] == 1
     assert streams[i]["info"]["effective_srate"] == 0
     assert streams[i]["info"]["segments"] == [(0, 0)]
+    assert streams[i]["info"]["clock_segments"] == (
+        [(0, 0)] if synchronize_clocks else []
+    )
 
     # Footer
     assert streams[i]["footer"]["info"]["first_timestamp"][0] == "91725.014004246"
@@ -288,6 +294,7 @@ def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     assert streams[i]["info"]["stream_id"] == 2
     assert streams[i]["info"]["effective_srate"] == 0
     assert streams[i]["info"]["segments"] == []
+    assert streams[i]["info"]["clock_segments"] == []
 
     # Footer
     assert streams[i]["footer"]["info"]["first_timestamp"][0] == "0"
@@ -349,6 +356,7 @@ def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     assert streams[i]["info"]["stream_id"] == 3
     assert streams[i]["info"]["effective_srate"] == 0
     assert streams[i]["info"]["segments"] == []
+    assert streams[i]["info"]["clock_segments"] == []
 
     # Footer
     assert streams[i]["footer"]["info"]["first_timestamp"][0] == "0"
@@ -410,6 +418,9 @@ def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     assert streams[i]["info"]["stream_id"] == 4
     assert streams[i]["info"]["effective_srate"] == pytest.approx(1)
     assert streams[i]["info"]["segments"] == [(0, 9)]
+    assert streams[i]["info"]["clock_segments"] == (
+        [(0, 9)] if synchronize_clocks else []
+    )
 
     # Footer
     assert streams[i]["footer"]["info"]["first_timestamp"][0] == "91725.21394789348"

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -340,7 +340,6 @@ def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
     assert streams[i]["info"]["name"][0] == "ctrl"
     assert streams[i]["info"]["type"][0] == "control"
     assert streams[i]["info"]["channel_count"][0] == "1"
-    assert streams[i]["info"]["nominal_srate"][0] == "0.000000000000000"
     assert streams[i]["info"]["channel_format"][0] == "string"
     assert streams[i]["info"]["source_id"][0] == "kassia"
     assert streams[i]["info"]["nominal_srate"][0] == "0.000000000000000"

--- a/test/test_detect_clock_resets.py
+++ b/test/test_detect_clock_resets.py
@@ -1,0 +1,319 @@
+import numpy as np
+import pytest
+from pyxdf.pyxdf import _detect_clock_resets
+
+from mock_data_stream import MockStreamData
+
+# No clock resets
+
+
+@pytest.mark.parametrize(
+    "n_clock_offsets, expected",
+    [(n, [(0, n - 1)]) for n in range(2, 10)],
+)
+def test_clock_no_resets(n_clock_offsets, expected):
+    clock_tdiff = 5
+    duration = n_clock_offsets * clock_tdiff
+    clock_times = list(range(0, duration, clock_tdiff))
+    clock_values = [0] * n_clock_offsets
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    time_thresh_stds = 5
+    time_thresh_secs = 5
+    value_thresh_stds = 10
+    value_thresh_secs = 1
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+def test_clock_no_resets_with_jitter():
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    jit_std = 0.02
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration, clock_tdiff)
+    clock_times = (
+        clock_times + rng.standard_normal(n_clock_offsets) * jit_std
+    ).tolist()
+    clock_values = (rng.standard_normal(n_clock_offsets) * jit_std).tolist()
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    time_thresh_stds = 5
+    time_thresh_secs = 5
+    value_thresh_stds = 10
+    value_thresh_secs = 1
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == [(0, 4)]
+
+
+# Clock resets
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        (5, 5, 10, 5, [(0, 0), (1, 4)]),
+        (2.71e16, 5, 10, 5, [(0, 4)]),
+        (5, 6, 10, 5, [(0, 4)]),
+        (5, 5, 2.71e16, 5, [(0, 4)]),
+        (5, 5, 10, 6, [(0, 4)]),
+    ],
+)
+def test_clock_jumps_forward(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    clock_times = list(range(0, duration, clock_tdiff))
+    clock_values = [0] * n_clock_offsets
+    # Reset after first clock offset measurement
+    clock_times[0] = -6
+    clock_values[0] = 6
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        (5, 5, 10, 5, [(0, 0), (1, 4)]),
+        (142, 5, 10, 5, [(0, 4)]),
+        (5, 6, 10, 5, [(0, 4)]),
+        (5, 5, 1285, 5, [(0, 4)]),
+        (5, 5, 10, 6, [(0, 4)]),
+    ],
+)
+def test_clock_jumps_forward_with_jitter(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    jit_std = 0.02
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration, clock_tdiff)
+    clock_times = (
+        clock_times + rng.standard_normal(n_clock_offsets) * jit_std
+    ).tolist()
+    clock_values = (rng.standard_normal(n_clock_offsets) * jit_std).tolist()
+    # Reset after first clock offset measurement
+    clock_times[0] = -6
+    clock_values[0] = 6
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        (5, 5, 10, 5, [(0, 4), (5, 9)]),
+        (312, 5, 10, 5, [(0, 9)]),
+        (5, 6, 10, 5, [(0, 9)]),
+        (5, 5, 101, 5, [(0, 9)]),
+        (5, 5, 10, 6, [(0, 9)]),
+    ],
+)
+def test_clock_jumps_forward_with_jitter_eq_len(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    jit_std = 0.02
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration * 2, clock_tdiff)
+    clock_times[n_clock_offsets:] += 6
+    clock_times = (
+        clock_times + rng.standard_normal(len(clock_times)) * jit_std
+    ).tolist()
+    clock_values = rng.standard_normal(len(clock_times)) * jit_std
+    clock_values[n_clock_offsets:] -= 6
+    clock_values = clock_values.tolist()
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        # Negative time intervals are always resets
+        (np.inf, np.inf, np.inf, np.inf, [(0, 0), (1, 4)]),
+    ],
+)
+def test_clock_jumps_backward(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    clock_times = list(range(0, duration, clock_tdiff))
+    clock_values = [0] * n_clock_offsets
+    # Reset after first clock offset measurement
+    clock_times[0] = 6
+    clock_values[0] = -6
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        # Negative time intervals are always resets
+        [np.inf, np.inf, np.inf, np.inf, [(0, 0), (1, 4)]],
+    ],
+)
+def test_clock_jumps_backward_with_jitter(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    jit_std = 0.02
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration, clock_tdiff)
+    clock_times = (
+        clock_times + rng.standard_normal(n_clock_offsets) * jit_std
+    ).tolist()
+    clock_values = (rng.standard_normal(n_clock_offsets) * jit_std).tolist()
+    # Reset after first clock offset measurement
+    clock_times[0] = 6
+    clock_values[0] = -6
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected
+
+
+@pytest.mark.parametrize(
+    "time_thresh_stds, time_thresh_secs, value_thresh_stds, value_thresh_secs, expected",
+    [
+        # Negative time intervals are always resets
+        [np.inf, np.inf, np.inf, np.inf, [(0, 4), (5, 9)]],
+    ],
+)
+def test_clock_jumps_backward_with_jitter_eq_len(
+    time_thresh_stds,
+    time_thresh_secs,
+    value_thresh_stds,
+    value_thresh_secs,
+    expected,
+):
+    clock_tdiff = 5
+    n_clock_offsets = 5
+    duration = n_clock_offsets * clock_tdiff
+    jit_std = 0.02
+    rng = np.random.default_rng(9)
+    clock_times = np.arange(0, duration * 2, clock_tdiff)
+    clock_times[n_clock_offsets:] -= 6
+    clock_times = (
+        clock_times + rng.standard_normal(len(clock_times)) * jit_std
+    ).tolist()
+    clock_values = rng.standard_normal(len(clock_times)) * jit_std
+    clock_values[n_clock_offsets:] += 6
+    clock_values = clock_values.tolist()
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    segments = _detect_clock_resets(
+        stream,
+        time_thresh_stds,
+        time_thresh_secs,
+        value_thresh_stds,
+        value_thresh_secs,
+    )
+    # Inclusive range
+    assert segments == expected

--- a/test/test_detect_clock_resets.py
+++ b/test/test_detect_clock_resets.py
@@ -4,6 +4,31 @@ from pyxdf.pyxdf import _detect_clock_resets
 
 from mock_data_stream import MockStreamData
 
+# Test error condition
+
+
+@pytest.mark.parametrize("n_clock_offsets", [0, 1])
+def test_detect_resets_length_error(n_clock_offsets):
+    clock_times = list(range(0, n_clock_offsets))
+    clock_values = [0] * n_clock_offsets
+    stream = MockStreamData(
+        clock_times=clock_times,
+        clock_values=clock_values,
+    )
+    time_thresh_stds = 5
+    time_thresh_secs = 5
+    value_thresh_stds = 10
+    value_thresh_secs = 1
+    with pytest.raises(ValueError):
+        _detect_clock_resets(
+            stream,
+            time_thresh_stds,
+            time_thresh_secs,
+            value_thresh_stds,
+            value_thresh_secs,
+        )
+
+
 # No clock resets
 
 


### PR DESCRIPTION
Possible fix for #93.

User visible changes:
- `_clock_sync` returns correctly synchronised streams when clock resets are detected (assuming timestamps are monotonic within segments)
- fix MAD calculation for clock values
- exposes `clock_segments` analogously to dejitter `segments`
- handles `LinAlgErrors` (with warning) during synchronisation

Internal changes:
- new tests and refactoring for tests and code reuse