### PR TITLE
Optionally handle non monotonic time-series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Add new `case_sensitive` parameter to `match_streaminfos`, defaulting to `False` to maintain previous behavior; when `False`, stream properties are matched more leniently ([#134](https://github.com/xdf-modules/pyxdf/pull/134) by [Stefan Appelhoff](https://github.com/sappelhoff))
 - Expose detected clock segments (used in synchronisation) as `stream["info"]["clock_segments"]` ([#131](https://github.com/xdf-modules/pyxdf/pull/131) by [Jamie Forth](https://github.com/jamieforth))
+- Add new `handle_non_monotonic` parameter to `load_xdf`, defaulting to `"warn"` to maintain previous behavior with additional warning when non-monotonic data are detected; when `None` check is bypassed entirely. Non-monotonic data are handled by sorting time-stamps (`"trust_timeseries"`) or by re-ordering samples according to sorted time-stamps (`"trust-timestamps"`) ([#132](https://github.com/xdf-modules/pyxdf/pull/132) by [Jamie Forth](https://github.com/jamieforth))
 
 ### Changed
 - Segment at negative time intervals when dejittering ([#130](https://github.com/xdf-modules/pyxdf/pull/130) by [Jamie Forth](https://github.com/jamieforth))

--- a/test/test_clock_sync.py
+++ b/test/test_clock_sync.py
@@ -587,7 +587,7 @@ def test_sync_clock_jumps_forward_break_at_reset_non_monotonic(
     handle_non_monotonic,
     expected,
 ):
-    # Non-monotonic time-stamps within clock regions.
+    # Non-monotonic time-stamps within clock regions
     time_stamps = [1, 3, 2, 4, 5] + [17, 18, 20, 19, 21]
     clock_times = [1, 6, 17, 22]
     clock_values = [-1, -1, -12, -12]
@@ -626,7 +626,7 @@ def test_sync_clock_jumps_forward_break_between_reset_non_monotonic(
     handle_non_monotonic,
     expected,
 ):
-    # Non-monotonic time-stamps between clock regions.
+    # Non-monotonic time-stamps between clock regions
     time_stamps = [4, 5, 6, 7, 8, 9, 11, 10] + [13, 12, 14, 15, 16, 17, 18, 19]
     clock_times = [1, 6, 17, 22]
     clock_values = [-1, -1, -3, -3]
@@ -665,7 +665,7 @@ def test_sync_clock_jumps_backward_break_at_reset_non_monotonic(
     handle_non_monotonic,
     expected,
 ):
-    # Non-monotonic time-stamps within clock regions.
+    # Non-monotonic time-stamps within clock regions
     time_stamps = [17, 19, 18, 20, 21] + [1, 2, 4, 3, 5]
     clock_times = [17, 22, 1, 6]
     clock_values = [-12, -12, 9, 9]
@@ -704,7 +704,7 @@ def test_sync_clock_jumps_backward_break_between_reset_non_monotonic(
     handle_non_monotonic,
     expected,
 ):
-    # Non-monotonic time-stamps between clock regions.
+    # Non-monotonic time-stamps between clock regions
     time_stamps = [17, 18, 19, 20, 21, 22, 24, 23] + [2, 1, 3, 4, 5, 6, 7, 8]
     clock_times = [17, 22, 1, 6]
     clock_values = [-12, -12, 9, 9]

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -192,10 +192,13 @@ def test_minimal_file_segments(jitter_break_threshold_seconds):
             assert stream["info"]["effective_srate"] == pytest.approx(0)
 
 
+@pytest.mark.parametrize("handle_non_monotonic", [None, False, True])
 @pytest.mark.parametrize("dejitter_timestamps", [False, True])
 @pytest.mark.parametrize("synchronize_clocks", [False, True])
 @pytest.mark.skipif("clock_resets" not in files, reason="File not found.")
-def test_clock_resets_file(synchronize_clocks, dejitter_timestamps):
+def test_clock_resets_file(
+    synchronize_clocks, dejitter_timestamps, handle_non_monotonic
+):
     path = files["clock_resets"]
     streams, header = load_xdf(
         path,
@@ -320,10 +323,13 @@ def test_clock_resets_file(synchronize_clocks, dejitter_timestamps):
     )
 
 
+@pytest.mark.parametrize("handle_non_monotonic", [None, False, True])
 @pytest.mark.parametrize("dejitter_timestamps", [False, True])
 @pytest.mark.parametrize("synchronize_clocks", [False, True])
 @pytest.mark.skipif("empty_streams" not in files, reason="File not found.")
-def test_empty_streams_file(synchronize_clocks, dejitter_timestamps):
+def test_empty_streams_file(
+    synchronize_clocks, dejitter_timestamps, handle_non_monotonic
+):
     path = files["empty_streams"]
     streams, header = load_xdf(
         path,

--- a/test/test_detect_breaks.py
+++ b/test/test_detect_breaks.py
@@ -121,36 +121,42 @@ def test_detect_breaks_non_monotonic(offset, threshold_seconds):
 
 
 # Sorted non-monotonic timeseries data - segment at time-intervals
-# between ascending-order time_stamps (intervals are always ≥ 0).
+# between ascending-order time_stamps (intervals are always ≥ 0)
 
 
-def test_detect_breaks_reverse_sorted():
+@pytest.mark.parametrize("reorder_timeseries", [False, True])
+def test_detect_breaks_reverse_sorted(reorder_timeseries):
     time_stamps = list(reversed(range(-5, 5)))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    stream = _sort_stream_data(1, stream)
-    # Timeseries should now also be sorted.
-    np.testing.assert_array_equal(stream.time_series[:, 0], sorted(time_stamps))
+    stream = _sort_stream_data(1, stream, reorder_timeseries=reorder_timeseries)
+    if reorder_timeseries:
+        # Timeseries should now also be sorted
+        np.testing.assert_array_equal(stream.time_series[:, 0], sorted(time_stamps))
     # if diff > 1 -> 0
     b_breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
     breaks = np.where(b_breaks)[0]
     assert breaks.size == 0
 
 
+@pytest.mark.parametrize("reorder_timeseries", [False, True])
 @pytest.mark.parametrize("fmt", ["float32", "string"])
 @pytest.mark.parametrize("threshold_seconds", [0.1, 1, 2])
 @pytest.mark.parametrize("offset", [-10, -1, 0, 10])
-def test_detect_breaks_non_monotonic_sorted(offset, threshold_seconds, fmt):
+def test_detect_breaks_non_monotonic_sorted(
+    offset, threshold_seconds, fmt, reorder_timeseries
+):
     time_stamps = [3] + [0, 1, 2] + [4, 5] + [7] + [5]
     time_stamps = np.array(time_stamps) + offset
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1, fmt=fmt)
-    stream = _sort_stream_data(1, stream)
-    # Timeseries data should now also be sorted.
-    if fmt == "string":
-        np.testing.assert_array_equal(
-            stream.time_series, [[str(float(x))] for x in sorted(time_stamps)]
-        )
-    else:
-        np.testing.assert_array_equal(stream.time_series[:, 0], sorted(time_stamps))
+    stream = _sort_stream_data(1, stream, reorder_timeseries)
+    if reorder_timeseries:
+        # Timeseries data should now also be sorted
+        if fmt == "string":
+            np.testing.assert_array_equal(
+                stream.time_series, [[str(float(x))] for x in sorted(time_stamps)]
+            )
+        else:
+            np.testing.assert_array_equal(stream.time_series[:, 0], sorted(time_stamps))
     b_breaks = _detect_breaks(
         stream,
         threshold_seconds=threshold_seconds,

--- a/test/test_jitter_removal.py
+++ b/test/test_jitter_removal.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
+from mock_data_stream import MockStreamData
+
 from pyxdf.pyxdf import _jitter_removal, _sort_stream_data
 
-from mock_data_stream import MockStreamData
+# Single-segment timeseries data
 
 
 @pytest.mark.parametrize(
@@ -23,7 +25,46 @@ def test_jitter_removal(t_start, t_end):
     assert stream.segments == [(0, len(time_stamps) - 1)]
     np.testing.assert_allclose(stream.time_stamps, time_stamps, atol=1e-14)
     np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
+    np.testing.assert_allclose(stream.effective_srate, srate, rtol=1e-15)
+
+
+@pytest.mark.parametrize(
+    "t_start, t_end",
+    [
+        (1, 1001),
+        (-1000, 0),
+        (-1000, 1001),
+    ],
+)
+def test_jitter_removal_with_jitter(t_start, t_end):
+    srate = 500
+    tdiff = 0.002
+    time_stamps_orig = np.arange(t_start, t_end, tdiff)
+    # Add jitter
+    jitter = tdiff * 0.001
+    rng = np.random.default_rng(9)
+    time_stamps = time_stamps_orig + rng.standard_normal(len(time_stamps_orig)) * jitter
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            srate=srate,
+            tdiff=tdiff,
+        )
+    }
+    _jitter_removal(streams, threshold_seconds=1, threshold_samples=500)
+    stream = streams[1]
+    assert stream.segments == [(0, len(time_stamps) - 1)]
+    np.testing.assert_allclose(
+        stream.time_stamps,
+        time_stamps_orig,
+        rtol=1e-05,
+        atol=1e-09,
+    )
+    np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
+    np.testing.assert_allclose(stream.effective_srate, srate, rtol=1e-10)
+
+
+# Multi-segment timeseries data
 
 
 @pytest.mark.parametrize(
@@ -48,9 +89,14 @@ def test_jitter_removal_two_segments(segments, t_starts):
     assert stream.segments == segments
     np.testing.assert_allclose(stream.time_stamps, time_stamps, atol=1e-14)
     np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
+    np.testing.assert_allclose(stream.effective_srate, srate, rtol=1e-15)
 
 
+# Non-monotonic timeseries data - handled by either sorting time-stamps or both
+# time-stamps and samples together
+
+
+@pytest.mark.parametrize("reorder_timeseries", [False, True])
 @pytest.mark.parametrize(
     "segments, t_starts",
     [
@@ -59,32 +105,9 @@ def test_jitter_removal_two_segments(segments, t_starts):
         ([(0, 19), (20, 39)], [11, -10]),
     ],
 )
-def test_jitter_removal_two_segments_non_monotonic(segments, t_starts):
-    srate = 1
-    tdiff = 1
-    time_stamps = [
-        np.arange(start_time, start_time + (seg_end - seg_start) + 1, tdiff)
-        for (seg_start, seg_end), start_time in zip(segments, t_starts)
-    ]
-    time_stamps = np.hstack(time_stamps)
-    streams = {1: MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff)}
-    _jitter_removal(streams, threshold_seconds=1, threshold_samples=1)
-    stream = streams[1]
-    assert stream.segments == segments
-    np.testing.assert_allclose(stream.time_stamps, time_stamps, atol=1e-13)
-    np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
-
-
-@pytest.mark.parametrize(
-    "segments, t_starts",
-    [
-        ([(0, 9), (10, 19)], [11, 0]),
-        ([(0, 9), (10, 19)], [1, -10]),
-        ([(0, 19), (20, 39)], [11, -10]),
-    ],
-)
-def test_jitter_removal_two_segments_non_monotonic_sorted(segments, t_starts):
+def test_jitter_removal_two_segments_non_monotonic_sorted(
+    segments, t_starts, reorder_timeseries
+):
     srate = 1
     tdiff = 1
     time_stamps = [
@@ -94,78 +117,40 @@ def test_jitter_removal_two_segments_non_monotonic_sorted(segments, t_starts):
     time_stamps = np.hstack(time_stamps)
     streams = {
         1: _sort_stream_data(
-            1, MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff)
+            1,
+            MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff),
+            reorder_timeseries,
         )
     }
     _jitter_removal(streams, threshold_seconds=1, threshold_samples=1)
     stream = streams[1]
     assert stream.segments == segments
     np.testing.assert_allclose(stream.time_stamps, sorted(time_stamps), atol=1e-14)
-    np.testing.assert_equal(stream.time_series[:, 0], sorted(time_stamps))
-    np.testing.assert_allclose(stream.effective_srate, srate)
+    if reorder_timeseries:
+        np.testing.assert_equal(stream.time_series[:, 0], sorted(time_stamps))
+    else:
+        np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
+    np.testing.assert_allclose(stream.effective_srate, srate, rtol=1e-15)
 
 
-def test_jitter_removal_glitch():
-    srate = 1
-    tdiff = 1
-    time_stamps = [1, 2, 3, 4] + [6] + [5, 7, 8, 9, 10]
-    streams = {1: MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff)}
-    _jitter_removal(streams, threshold_seconds=1, threshold_samples=1)
-    stream = streams[1]
-    assert stream.segments == [(0, 3), (4, 4), (5, 5), (6, 9)]
-    np.testing.assert_allclose(stream.time_stamps, time_stamps)
-    np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
-
-
-def test_jitter_removal_glitch_sorted():
+@pytest.mark.parametrize("reorder_timeseries", [False, True])
+def test_jitter_removal_glitch_sorted(reorder_timeseries):
     srate = 1
     tdiff = 1
     time_stamps = [1, 2, 3, 4] + [6] + [5, 7, 8, 9, 10]
     streams = {
         1: _sort_stream_data(
-            1, MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff)
+            1,
+            MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff),
+            reorder_timeseries,
         )
     }
     _jitter_removal(streams, threshold_seconds=1, threshold_samples=1)
     stream = streams[1]
     assert stream.segments == [(0, len(time_stamps) - 1)]
-    np.testing.assert_allclose(stream.time_stamps, sorted(time_stamps))
-    np.testing.assert_equal(stream.time_series[:, 0], sorted(time_stamps))
-    np.testing.assert_allclose(stream.effective_srate, srate)
-
-
-@pytest.mark.parametrize(
-    "t_start, t_end",
-    [
-        (1, 1001),
-        (-1000, 0),
-        (-1000, 1001),
-    ],
-)
-def test_jitter_removal_with_jitter(t_start, t_end):
-    srate = 500
-    tdiff = 0.002
-    time_stamps_orig = np.arange(t_start, t_end, tdiff)
-    # Add jitter.
-    jitter = tdiff * 0.001
-    rng = np.random.default_rng(9)
-    time_stamps = time_stamps_orig + rng.standard_normal(len(time_stamps_orig)) * jitter
-    streams = {
-        1: MockStreamData(
-            time_stamps=time_stamps,
-            srate=srate,
-            tdiff=tdiff,
-        )
-    }
-    _jitter_removal(streams, threshold_seconds=1, threshold_samples=500)
-    stream = streams[1]
-    assert stream.segments == [(0, len(time_stamps) - 1)]
-    np.testing.assert_allclose(
-        stream.time_stamps,
-        time_stamps_orig,
-        rtol=1e-05,
-        atol=1e-09,
-    )
-    np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
+    np.testing.assert_allclose(stream.time_stamps, sorted(time_stamps), rtol=1e-14)
+    if reorder_timeseries:
+        np.testing.assert_equal(stream.time_series[:, 0], sorted(time_stamps))
+    else:
+        np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
+    np.testing.assert_allclose(stream.effective_srate, srate, rtol=1e-15)

--- a/test/test_monotonic.py
+++ b/test/test_monotonic.py
@@ -1,0 +1,210 @@
+import pytest
+from pyxdf.pyxdf import _check_monotonicity, _monotonic_increasing
+
+from mock_data_stream import MockStreamData
+
+# Monotonic data.
+
+
+def test_empty_list():
+    a = []
+    monotonicity = _monotonic_increasing(a)
+    assert monotonicity.result is True
+    assert monotonicity.n == 0
+    assert monotonicity.dec_count == 0
+    assert monotonicity.eq_count == 0
+
+
+def test_single_item_list():
+    a = [0]
+    monotonicity = _monotonic_increasing(a)
+    assert monotonicity.result is True
+    assert monotonicity.n == 0
+    assert monotonicity.dec_count == 0
+    assert monotonicity.eq_count == 0
+
+
+def test_strict_increasing():
+    a = list(range(-4, 5))
+    monotonicity = _monotonic_increasing(a)
+    assert monotonicity.result is True
+    assert monotonicity.n == len(a) - 1
+    assert monotonicity.dec_count == 0
+    assert monotonicity.eq_count == 0
+
+
+@pytest.mark.parametrize(
+    "a, expected_dec_count, expected_eq_count",
+    (
+        ([-4] + list(range(-4, 5)), 0, 1),
+        (list(range(-4, 5)) + [4], 0, 1),
+        ([-4, -3, -2, -1, -1, 0, 1, 2, 3, 4], 0, 1),
+        ([-4, -3, -2, -1, 0, 1, 1, 2, 3, 4], 0, 1),
+        ([-4, -3, -2, -2, -1, 0, 1, 2, 2, 3, 4], 0, 2),
+    ),
+)
+def test_non_decreasing(a, expected_dec_count, expected_eq_count):
+    monotonicity = _monotonic_increasing(a)
+    assert monotonicity.result is True
+    assert monotonicity.n == len(a) - 1
+    assert monotonicity.dec_count == expected_dec_count
+    assert monotonicity.eq_count == expected_eq_count
+
+
+# Non-monotonic data.
+
+
+@pytest.mark.parametrize(
+    "a, expected_dec_count, expected_eq_count",
+    (
+        ([-4, -2, -3, -1, 0, 1, 2, 3, 4], 1, 0),
+        ([-4, -3, -2, -1, 0, 1, 3, 2, 4], 1, 0),
+        ([-4, -3, -2, -1, 0, -1, 2, 3, 4], 1, 0),
+        ([-4, -4, -3, -2, -1, 0, -1, 2, 3, 4], 1, 1),
+        ([-4, -3, -2, -1, 0, -1, 2, 3, 3, 4], 1, 1),
+        ([-4, -2, -3, -1, 0, 1, 3, 2, 4], 2, 0),
+        ([-4, -2, -3, -1, 0, 0, 1, 3, 2, 4], 2, 1),
+        ([-4, -4, -2, -3, -1, 0, 1, 3, 2, 4, 4], 2, 2),
+    ),
+)
+def test_decreasing(a, expected_dec_count, expected_eq_count):
+    monotonicity = _monotonic_increasing(a)
+    assert monotonicity.result is False
+    assert monotonicity.n == len(a) - 1
+    assert monotonicity.dec_count == expected_dec_count
+    assert monotonicity.eq_count == expected_eq_count
+
+
+# Monotonic streams: test both time-stamps and clock-times.
+
+
+def test_strict_increasing_stream():
+    time_stamps = list(range(-4, 5))
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=time_stamps,
+        )
+    }
+    monotonicity = _check_monotonicity(streams)
+    assert monotonicity["time_stamps"][1] is True
+    assert monotonicity["clock_times"][1] is True
+
+
+@pytest.mark.parametrize(
+    "time_stamps",
+    (
+        [-4] + list(range(-4, 5)),
+        list(range(-4, 5)) + [4],
+        [-4, -3, -2, -1, -1, 0, 1, 2, 3, 4],
+        [-4, -3, -2, -1, 0, 1, 1, 2, 3, 4],
+        [-4, -3, -2, -2, -1, 0, 1, 2, 2, 3, 4],
+    ),
+)
+def test_non_decreasing_stream(time_stamps):
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=time_stamps,
+        )
+    }
+    monotonicity = _check_monotonicity(streams)
+    assert monotonicity["time_stamps"][1] is True
+    assert monotonicity["clock_times"][1] is True
+
+
+# Non-monotonic streams.
+
+
+@pytest.mark.parametrize(
+    "time_stamps",
+    (
+        [-4, -2, -3, -1, 0, 1, 2, 3, 4],
+        [-4, -3, -2, -1, 0, 1, 3, 2, 4],
+        [-4, -3, -2, -1, 0, -1, 2, 3, 4],
+        [-4, -4, -3, -2, -1, 0, -1, 2, 3, 4],
+        [-4, -3, -2, -1, 0, -1, 2, 3, 3, 4],
+        [-4, -2, -3, -1, 0, 1, 3, 2, 4],
+        [-4, -2, -3, -1, 0, 0, 1, 3, 2, 4],
+        [-4, -4, -2, -3, -1, 0, 1, 3, 2, 4, 4],
+    ),
+)
+def test_decreasing_stream(time_stamps):
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            # Reversed non-monotonic data will still be non-monotonic, but
+            # with different statistics.
+            clock_times=list(reversed(time_stamps)),
+        )
+    }
+    monotonicity = _check_monotonicity(streams)
+    assert monotonicity["time_stamps"][1] is False
+    assert monotonicity["clock_times"][1] is False
+
+
+# Mixed monotonic/non-monotonic time-stamps and clock-times.
+
+
+@pytest.mark.parametrize(
+    "time_stamps, clock_times, expected_ts, expected_ct",
+    (
+        (list(range(-4, 5)), list(reversed(range(-4, 5))), True, False),
+        (list(reversed(range(-4, 5))), list(range(-4, 5)), False, True),
+    ),
+)
+def test_mixed_strict_increasing_stream(
+    time_stamps,
+    clock_times,
+    expected_ts,
+    expected_ct,
+):
+    streams = {
+        1: MockStreamData(
+            time_stamps=time_stamps,
+            clock_times=clock_times,
+        )
+    }
+    monotonicity = _check_monotonicity(streams)
+    assert monotonicity["time_stamps"][1] is expected_ts
+    assert monotonicity["clock_times"][1] is expected_ct
+
+
+# Multiple mixed monotonic/non-monotonic time-stamps and clock-times.
+
+
+def test_multiple_strict_increasing_stream():
+    time_stamps = list(range(-4, 5))
+    streams = {
+        1: MockStreamData(
+            stream_id=1,
+            time_stamps=time_stamps,
+            clock_times=time_stamps,
+        ),
+        2: MockStreamData(
+            stream_id=2,
+            time_stamps=time_stamps,
+            clock_times=list(reversed(time_stamps)),
+        ),
+        3: MockStreamData(
+            stream_id=3,
+            time_stamps=list(reversed(time_stamps)),
+            clock_times=time_stamps,
+        ),
+        4: MockStreamData(
+            stream_id=4,
+            time_stamps=list(reversed(time_stamps)),
+            clock_times=list(reversed(time_stamps)),
+        ),
+    }
+    monotonicity = _check_monotonicity(streams)
+    assert all(monotonicity["time_stamps"].values()) is False
+    assert all(monotonicity["clock_times"].values()) is False
+    assert monotonicity["time_stamps"][1] is True
+    assert monotonicity["clock_times"][1] is True
+    assert monotonicity["time_stamps"][2] is True
+    assert monotonicity["clock_times"][2] is False
+    assert monotonicity["time_stamps"][3] is False
+    assert monotonicity["clock_times"][3] is True
+    assert monotonicity["time_stamps"][4] is False
+    assert monotonicity["clock_times"][4] is False

--- a/test/test_monotonic.py
+++ b/test/test_monotonic.py
@@ -3,7 +3,7 @@ from pyxdf.pyxdf import _check_monotonicity, _monotonic_increasing
 
 from mock_data_stream import MockStreamData
 
-# Monotonic data.
+# Monotonic data
 
 
 def test_empty_list():
@@ -51,7 +51,7 @@ def test_non_decreasing(a, expected_dec_count, expected_eq_count):
     assert monotonicity.eq_count == expected_eq_count
 
 
-# Non-monotonic data.
+# Non-monotonic data
 
 
 @pytest.mark.parametrize(
@@ -75,7 +75,7 @@ def test_decreasing(a, expected_dec_count, expected_eq_count):
     assert monotonicity.eq_count == expected_eq_count
 
 
-# Monotonic streams: test both time-stamps and clock-times.
+# Monotonic streams: test both time-stamps and clock-times
 
 
 def test_strict_increasing_stream():
@@ -113,7 +113,7 @@ def test_non_decreasing_stream(time_stamps):
     assert monotonicity["clock_times"][1] is True
 
 
-# Non-monotonic streams.
+# Non-monotonic streams
 
 
 @pytest.mark.parametrize(
@@ -134,7 +134,7 @@ def test_decreasing_stream(time_stamps):
         1: MockStreamData(
             time_stamps=time_stamps,
             # Reversed non-monotonic data will still be non-monotonic, but
-            # with different statistics.
+            # with different statistics
             clock_times=list(reversed(time_stamps)),
         )
     }
@@ -143,7 +143,7 @@ def test_decreasing_stream(time_stamps):
     assert monotonicity["clock_times"][1] is False
 
 
-# Mixed monotonic/non-monotonic time-stamps and clock-times.
+# Mixed monotonic/non-monotonic time-stamps and clock-times
 
 
 @pytest.mark.parametrize(
@@ -170,7 +170,7 @@ def test_mixed_strict_increasing_stream(
     assert monotonicity["clock_times"][1] is expected_ct
 
 
-# Multiple mixed monotonic/non-monotonic time-stamps and clock-times.
+# Multiple mixed monotonic/non-monotonic time-stamps and clock-times
 
 
 def test_multiple_strict_increasing_stream():

--- a/test/test_segment_indices.py
+++ b/test/test_segment_indices.py
@@ -37,7 +37,7 @@ def test_segments(b_breaks, expected):
                 n_breaks,
                 list(itertools.combinations(range(0, size), n_breaks)),
             )
-            # All sequences of length 3 to 5, continuing from the tests above.
+            # All sequences of length 3 to 5, continuing from the tests above
             for size in range(3, 6)
             # All numbers of breaks between 0 and size
             for n_breaks in range(0, size + 1)


### PR DESCRIPTION
Attempt to handle out-of-order timestamps/samples.

New load_xdf parameter: `handle_non_monotonic` (default: "warn")
  - None: disable monotonicity checking (previous behaviour)
  - "warn": check and warn only (otherwise previous behaviour)
  - "trust_timeseries": sort time-stamps only
  - "trust_timestamps": sort time-stamps and reorder time-series data accordingly

Sometimes LabRecorder XDF files contain out-of-order ground-truth time-stamps (~3% in my case). The problem seems to originate in certain device-specific proprietary software generating the LSL streams – not LSL itself, LabRecorder or network infrastructure.

This PR helps process such files by clock-segment-wise sorting time-stamps (and optionally reordering samples) after synchronisation and before dejittering, thus avoiding highly segmented streams. When non-monotonic data are detected the user must determine whether to trust the original time-stamps or sample sequence order, or just ignore/disable the check if this is not important for them. 

If this PR is just a workaround for one broken device it probably doesn't belong in `pyxdf`. An alternative could be to instead provide a new load parameter for the user to pass in a custom function to be applied before dejittering, similar to `on_chunk`.  

I don't have a strong preference, but on the other hand this doesn't introduce any breaking changes, the default behaviour has a negligible impact on load time (e.g. <1 second difference loading a 3GB file on my laptop according to `timeit`) and it's generally a good thing to give users a heads up about potential problems with their data.
