### PR TITLE
detected breaks not only if diffs are positive, but use abs(diffs)

### DIFF
--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -739,9 +739,8 @@ def _detect_breaks(stream, threshold_seconds=1.0, threshold_samples=500):
         b_breaks : 1D bool array representing breaks between values.
     """
     diffs = np.diff(stream.time_stamps)
-    b_breaks = (diffs < 0) | (
-        diffs > np.max((threshold_seconds, threshold_samples * stream.tdiff))
-    )
+
+    b_breaks = np.abs(diffs) > np.max((threshold_seconds, threshold_samples * stream.tdiff))
     return b_breaks
 
 


### PR DESCRIPTION
Fixes #137

I did not run tests locally because I dont have the tooling installed