### PR TITLE
Fix TypeError when channel/acquisition metadata contains None values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- Fix `playback_lsl.py` for cases where no metadata is available in the to-be-streamed XDF file ([#160] by [Stefan Appelhoff](https://github.com/sappelhoff))
 
 ## [1.17.3] - 2026-01-20
 ### Fixed

--- a/src/pyxdf/cli/playback_lsl.py
+++ b/src/pyxdf/cli/playback_lsl.py
@@ -27,16 +27,16 @@ def _create_info_from_xdf_stream_header(header):
             _acq = _desc["acquisition"][0]
             acq = desc.append_child("acquisition")
             for k in ["manufacturer", "model", "precision", "compensated_lag"]:
-                if k in _acq:
-                    acq.append_child_value(k, _acq[k][0])
+                if k in _acq and _acq[k][0] is not None:
+                    acq.append_child_value(k, str(_acq[k][0]))
         if "channels" in _desc:
             _chans = _desc["channels"][0]
             chans = desc.append_child("channels")
             for _ch in _chans["channel"]:
                 ch = chans.append_child("channel")
                 for k in ["label", "unit", "type", "scaling_factor"]:
-                    if k in _ch:
-                        ch.append_child_value(k, _ch[k][0])
+                    if k in _ch and _ch[k][0] is not None:
+                        ch.append_child_value(k, str(_ch[k][0]))
                 # loc = ch.append_child("location")
                 # for dim_ix, dim in enumerate(["X", "Y", "Z"]):
                 #     loc.append_child_value(dim, str(elec_coords[ch_ix, dim_ix]))


### PR DESCRIPTION
Disclaimer: I created this PR and the content using Claude.

---

## Summary

`playback_lsl.py` crashes with a `TypeError` when an XDF file contains channel or acquisition metadata fields that are present but have `None` values:

```
TypeError: descriptor 'encode' for 'str' objects doesn't apply to a 'NoneType' object
```

This happens in `pylsl`'s `append_child_value`, which calls `str.encode()` on the value passed to it.

## Fix

- Skip metadata fields whose value is `None` (guard added to both the `acquisition` and `channel` loops)
- Wrap values in `str()` so non-string scalars (e.g. a numeric `precision` field) are also handled correctly

## Test plan

- [x] Reproduce with an XDF file that has `None` channel metadata (e.g. a missing `unit` field) — previously crashed, now streams successfully
- [x] Verify that XDF files with fully populated metadata still stream correctly