### PR TITLE
Precompute little-endian sample dtype once per stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Changed
-- Precompute the little-endian sample dtype once per stream instead of per sample in `_read_chunk3`, speeding up loading of large numeric streams (~8% faster on a 553k-sample, 99-channel EEG recording) with byte-identical output ([#PR] by [Stefan Appelhoff](https://github.com/sappelhoff))
+- Precompute the little-endian sample dtype once per stream instead of per sample in `_read_chunk3`, speeding up loading of large numeric streams (~8% faster on a 553k-sample, 99-channel EEG recording) with byte-identical output ([#170](https://github.com/xdf-modules/pyxdf/pull/170) by [Stefan Appelhoff](https://github.com/sappelhoff))
 
 ### Fixed
 - Fix `playback_lsl.py` for cases where no metadata is available in the to-be-streamed XDF file ([#160] by [Stefan Appelhoff](https://github.com/sappelhoff))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- Precompute the little-endian sample dtype once per stream instead of per sample in `_read_chunk3`, speeding up loading of large numeric streams (~8% faster on a 553k-sample, 99-channel EEG recording) with byte-identical output ([#PR] by [Stefan Appelhoff](https://github.com/sappelhoff))
+
 ### Fixed
 - Fix `playback_lsl.py` for cases where no metadata is available in the to-be-streamed XDF file ([#160] by [Stefan Appelhoff](https://github.com/sappelhoff))
 

--- a/src/pyxdf/pyxdf.pxd
+++ b/src/pyxdf/pyxdf.pxd
@@ -7,7 +7,7 @@ cdef class StreamData:
     cdef readonly int nchns, samplebytes
     cdef readonly fmt
     cdef public double effective_srate
-    cdef public time_stamps, time_series, clock_times, clock_values, dtype, fmts
+    cdef public time_stamps, time_series, clock_times, clock_values, dtype, dtype_le, fmts
 
 cdef bytearray _read_varlen_int_buf
 

--- a/src/pyxdf/pyxdf.py
+++ b/src/pyxdf/pyxdf.py
@@ -68,6 +68,9 @@ class StreamData:
         # pre-calc some parsing parameters for efficiency
         if self.fmt != "string":
             self.dtype = np.dtype(fmts[self.fmt])
+            # little-endian view of the dtype, precomputed once because it is used
+            # once per sample in _read_chunk3 (XDF sample data is little-endian)
+            self.dtype_le = self.dtype.newbyteorder("<")
             # number of bytes to read from stream to handle one sample
             self.samplebytes = self.nchns * self.dtype.itemsize
 
@@ -478,9 +481,7 @@ def _read_chunk3(f, s):
             # read the values
             f.readinto(raw)
             # no fromfile(), see https://github.com/numpy/numpy/issues/13319
-            values[k, :] = np.frombuffer(
-                raw, dtype=s.dtype.newbyteorder("<"), count=s.nchns
-            )
+            values[k, :] = np.frombuffer(raw, dtype=s.dtype_le, count=s.nchns)
     return nsamples, stamps, values
 
 


### PR DESCRIPTION
**NOTE** I generated this PR with the help of Claude as part of a general memory/speed profiling I am doing for a private package of mine.

## What

`_read_chunk3` reinterprets each numeric sample buffer as little-endian via `np.frombuffer(raw, dtype=s.dtype.newbyteorder("<"), count=s.nchns)`. `s.dtype.newbyteorder("<")` returns the same dtype object every time but was being recomputed **once per sample**. This moves it to `StreamData.__init__` (`s.dtype_le`, alongside the existing `dtype`/`samplebytes` pre-calcs) and reuses it.

## Why it's behaviour-preserving

- XDF sample data is little-endian, and the original code already hardcoded `"<"` regardless of platform — `s.dtype_le = s.dtype.newbyteorder("<")` is the identical value, so output is **byte-identical** (including on big-endian hosts).
- `dtype_le` is set under the same `if self.fmt != "string":` guard that already gates `self.dtype`, and its only use is the numeric branch of `_read_chunk3`. String streams never set or read it. Empty streams never call `_read_chunk3`.
- `newbyteorder` is dtype-generic (no type-specific branch), so all numeric formats behave identically.

The `.pxd` Cython declaration is updated to keep `StreamData` in sync.

## Verification

- Full suite: **372 passed, 1 xfailed** (with `example-files/` cloned), covering int16/int32/float32/double64/string/empty streams — every sample-reading path.
- **Byte-identical** per-stream `time_series`/`time_stamps` md5 on a real 224 MB recording (99-ch EEG @ 500 Hz + marker/logging/notes/misc streams), baseline vs this branch.
- ~**8% faster** `load_xdf` on that recording (median 1.014 s → 0.935 s, 6 reps), as the per-sample `newbyteorder` (553k calls) is eliminated.